### PR TITLE
Use graph stream in nodes

### DIFF
--- a/src/CudaEvent.hpp
+++ b/src/CudaEvent.hpp
@@ -25,7 +25,7 @@ struct CudaEvent {
         return CudaEvent::Ptr(new CudaEvent(flag));
     }
 
-    cudaEvent_t get() { return event; }
+    cudaEvent_t getHandle() { return event; }
 
     ~CudaEvent()
     {

--- a/src/CudaStream.hpp
+++ b/src/CudaStream.hpp
@@ -41,7 +41,7 @@ struct CudaStream
 		return copyStream;
 	}
 
-	cudaStream_t get() { return stream; }
+	cudaStream_t getHandle() { return stream; }
 
 	~CudaStream()
 	{

--- a/src/VArray.cpp
+++ b/src/VArray.cpp
@@ -42,6 +42,7 @@ void* VArray::getWritePtr(MemLoc location)
 }
 
 
+
 VArray::Ptr VArray::create(rgl_field_t type, std::size_t initialSize)
 {
 	return createVArray(type, initialSize);
@@ -103,6 +104,7 @@ void VArray::reserve(std::size_t newCapacity, bool preserveData)
 
 	current().data = newMem;
 	current().elemCapacity = newCapacity;
+	CHECK_CUDA(cudaStreamSynchronize(nullptr));
 }
 
 VArray::~VArray()
@@ -126,6 +128,7 @@ void* VArray::memAlloc(std::size_t bytes, std::optional<MemLoc> locationHint) co
 		CHECK_CUDA(cudaMalloc(&ptr, bytes));
 		CHECK_CUDA(cudaStreamSynchronize(nullptr));
 	}
+	CHECK_CUDA(cudaStreamSynchronize(nullptr));
 	return ptr;
 }
 
@@ -139,6 +142,7 @@ void VArray::memFree(void* ptr, std::optional<MemLoc> locationHint) const
 		CHECK_CUDA(cudaFree(ptr));
 		CHECK_CUDA(cudaStreamSynchronize(nullptr));
 	}
+	CHECK_CUDA(cudaStreamSynchronize(nullptr));
 }
 
 void VArray::migrateToLocation(MemLoc newLoc)

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -413,7 +413,7 @@ rgl_graph_get_result_data(rgl_node_t node, rgl_field_t field, void* data)
 
 		auto pointCloudNode = Node::validatePtr<IPointsNode>(node);
 		pointCloudNode->waitForResults();
-		VArray::ConstPtr output = pointCloudNode->getFieldData(field, nullptr);
+		VArray::ConstPtr output = pointCloudNode->getFieldData(field);
 
 		// TODO: cudaMemcpyAsync + explicit sync can be used here (better behavior for multiple graphs)
 		CHECK_CUDA(cudaMemcpy(data, output->getReadPtr(MemLoc::Device), output->getElemCount() * output->getElemSize(), cudaMemcpyDefault));

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -415,8 +415,13 @@ rgl_graph_get_result_data(rgl_node_t node, rgl_field_t field, void* data)
 		pointCloudNode->waitForResults();
 		VArray::ConstPtr output = pointCloudNode->getFieldData(field);
 
-		// TODO: cudaMemcpyAsync + explicit sync can be used here (better behavior for multiple graphs)
-		CHECK_CUDA(cudaMemcpy(data, output->getReadPtr(MemLoc::Device), output->getElemCount() * output->getElemSize(), cudaMemcpyDefault));
+		// TODO: Ensure that copying to pageable memory does not wait
+		CHECK_CUDA(cudaMemcpyAsync(data,
+		                           output->getReadPtr(MemLoc::Device),
+		                           output->getElemCount() * output->getElemSize(),
+		                           cudaMemcpyDefault,
+		                           CudaStream::getCopyStream()->getHandle()));
+		CHECK_CUDA(cudaStreamSynchronize(CudaStream::getCopyStream()->getHandle()));
 	});
 	TAPE_HOOK(node, field, data);
 	return status;

--- a/src/graph/FormatPointsNode.cpp
+++ b/src/graph/FormatPointsNode.cpp
@@ -25,9 +25,9 @@ void FormatPointsNode::setParameters(const std::vector<rgl_field_t>& fields)
 	this->fields = fields;
 }
 
-void FormatPointsNode::enqueueExecImpl(cudaStream_t stream)
+void FormatPointsNode::enqueueExecImpl()
 {
-	formatAsync(output, input, fields, stream, gpuFieldDescBuilder);
+	formatAsync(output, input, fields, getStreamHandle(), gpuFieldDescBuilder);
 }
 
 void FormatPointsNode::formatAsync(const VArray::Ptr& output, const IPointsNode::Ptr& input,
@@ -37,12 +37,12 @@ void FormatPointsNode::formatAsync(const VArray::Ptr& output, const IPointsNode:
 	std::size_t pointSize = getPointSize(fields);
 	std::size_t pointCount = input->getPointCount();
 	output->resize(pointCount * pointSize, false, false);
-	auto gpuFields = gpuFieldDescBuilder.buildReadable(getFieldToPointerMappings(input, fields, stream));
+	auto gpuFields = gpuFieldDescBuilder.buildReadable(getFieldToPointerMappings(input, fields));
 	char* outputPtr = static_cast<char*>(output->getWritePtr(MemLoc::Device));
 	gpuFormatSoaToAos(stream, pointCount, pointSize, fields.size(), gpuFields->getReadPtr(), outputPtr);
 }
 
-VArray::ConstPtr FormatPointsNode::getFieldData(rgl_field_t field, cudaStream_t stream)
+VArray::ConstPtr FormatPointsNode::getFieldData(rgl_field_t field)
 {
 	if (field == RGL_FIELD_DYNAMIC_FORMAT) {
 		return output;
@@ -59,12 +59,11 @@ std::size_t FormatPointsNode::getFieldPointSize(rgl_field_t field) const
 }
 
 std::vector<std::pair<rgl_field_t, const void*>> FormatPointsNode::getFieldToPointerMappings(const IPointsNode::Ptr& input,
-                                                                                             const std::vector<rgl_field_t>& fields,
-                                                                                             cudaStream_t stream)
+                                                                                             const std::vector<rgl_field_t>& fields)
 {
 	std::vector<std::pair<rgl_field_t, const void*>> outFieldsData;
 	for (auto&& field : fields) {
-		outFieldsData.push_back({field, isDummy(field) ? nullptr : input->getFieldData(field, stream)->getReadPtr(MemLoc::Device)});
+		outFieldsData.push_back({field, isDummy(field) ? nullptr : input->getFieldData(field)->getReadPtr(MemLoc::Device)});
 	}
 	return outFieldsData;
 }

--- a/src/graph/FormatPointsNode.cpp
+++ b/src/graph/FormatPointsNode.cpp
@@ -47,7 +47,7 @@ VArray::ConstPtr FormatPointsNode::getFieldData(rgl_field_t field)
 	if (field == RGL_FIELD_DYNAMIC_FORMAT) {
 		return output;
 	}
-	return input->getFieldData(field, CudaStream::getCopyStream()->get());
+	return input->getFieldData(field);
 }
 
 std::size_t FormatPointsNode::getFieldPointSize(rgl_field_t field) const

--- a/src/graph/FromArrayPointsNode.cpp
+++ b/src/graph/FromArrayPointsNode.cpp
@@ -36,8 +36,9 @@ void FromArrayPointsNode::setParameters(const void* points, size_t pointCount, c
 	std::size_t pointSize = getPointSize(fields);
 	auto gpuFields = gpuFieldDescBuilder.buildWritable(getFieldToPointerMappings(fields));
 	const char* inputPtr = static_cast<const char*>(inputData->getReadPtr(MemLoc::Device));
+
+	// Immediately copy data to the GPU. We may not have stream yet, so use NULL stream and synchronize it.
 	gpuFormatAosToSoa(nullptr, pointCount, pointSize, fields.size(), inputPtr, gpuFields->getWritePtr());
-	// TODO(msz-rai): check synchronize is necessary
 	CHECK_CUDA(cudaStreamSynchronize(nullptr));
 }
 

--- a/src/graph/GaussianNoiseAngularHitpointNode.cpp
+++ b/src/graph/GaussianNoiseAngularHitpointNode.cpp
@@ -39,7 +39,7 @@ void GaussianNoiseAngularHitpointNode::validateImpl()
 	}
 }
 
-void GaussianNoiseAngularHitpointNode::enqueueExecImpl(cudaStream_t stream)
+void GaussianNoiseAngularHitpointNode::enqueueExecImpl()
 {
 	auto pointCount = input->getPointCount();
 	outXyz->resize(pointCount, false, false);
@@ -55,23 +55,23 @@ void GaussianNoiseAngularHitpointNode::enqueueExecImpl(cudaStream_t stream)
 		gpuSetupGaussianNoiseGenerator(nullptr, pointCount, randomDevice(), randomizationStates->getDevicePtr());
 	}
 
-	const auto inXyz = input->getFieldDataTyped<XYZ_F32>(stream);
+	const auto inXyz = input->getFieldDataTyped<XYZ_F32>();
 	const auto* inXyzPtr = inXyz->getDevicePtr();
 	auto* outXyzPtr = outXyz->getDevicePtr();
-	gpuAddGaussianNoiseAngularHitpoint(stream, pointCount, mean, stDev, rotationAxis, lookAtOriginTransform, randomizationStates->getDevicePtr(), inXyzPtr, outXyzPtr, outDistancePtr);
+	gpuAddGaussianNoiseAngularHitpoint(getStreamHandle(), pointCount, mean, stDev, rotationAxis, lookAtOriginTransform, randomizationStates->getDevicePtr(), inXyzPtr, outXyzPtr, outDistancePtr);
 }
 
-VArray::ConstPtr GaussianNoiseAngularHitpointNode::getFieldData(rgl_field_t field, cudaStream_t stream)
+VArray::ConstPtr GaussianNoiseAngularHitpointNode::getFieldData(rgl_field_t field)
 {
 	if (field == XYZ_F32) {
 		// TODO(msz-rai): check synchronize is necessary
-		CHECK_CUDA(cudaStreamSynchronize(stream));
+		CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 		return outXyz->untyped();
 	}
 	if (field == DISTANCE_F32 && outDistance != nullptr) {
 		// TODO(msz-rai): check synchronize is necessary
-		CHECK_CUDA(cudaStreamSynchronize(stream));
+		CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 		return outDistance->untyped();
 	}
-	return input->getFieldData(field, stream);
+	return input->getFieldData(field);
 }

--- a/src/graph/GaussianNoiseAngularHitpointNode.cpp
+++ b/src/graph/GaussianNoiseAngularHitpointNode.cpp
@@ -52,7 +52,7 @@ void GaussianNoiseAngularHitpointNode::enqueueExecImpl()
 
 	if (randomizationStates->getCount() < pointCount) {
 		randomizationStates->resize(pointCount, false, false);
-		gpuSetupGaussianNoiseGenerator(nullptr, pointCount, randomDevice(), randomizationStates->getDevicePtr());
+		gpuSetupGaussianNoiseGenerator(getStreamHandle(), pointCount, randomDevice(), randomizationStates->getDevicePtr());
 	}
 
 	const auto inXyz = input->getFieldDataTyped<XYZ_F32>();

--- a/src/graph/GaussianNoiseAngularRayNode.cpp
+++ b/src/graph/GaussianNoiseAngularRayNode.cpp
@@ -32,7 +32,7 @@ void GaussianNoiseAngularRaysNode::validateImpl()
 
 	if (randomizationStates->getCount() < rayCount) {
 		randomizationStates->resize(rayCount, false, false);
-		gpuSetupGaussianNoiseGenerator(nullptr, rayCount, randomDevice(), randomizationStates->getDevicePtr());
+		gpuSetupGaussianNoiseGenerator(getStreamHandle(), rayCount, randomDevice(), randomizationStates->getDevicePtr());
 	}
 }
 

--- a/src/graph/GaussianNoiseAngularRayNode.cpp
+++ b/src/graph/GaussianNoiseAngularRayNode.cpp
@@ -36,9 +36,9 @@ void GaussianNoiseAngularRaysNode::validateImpl()
 	}
 }
 
-void GaussianNoiseAngularRaysNode::enqueueExecImpl(cudaStream_t stream)
+void GaussianNoiseAngularRaysNode::enqueueExecImpl()
 {
 	const auto* inRaysPtr = input->getRays()->getDevicePtr();
 	auto* outRaysPtr = rays->getDevicePtr();
-	gpuAddGaussianNoiseAngularRay(stream, getRayCount(), mean, stDev, rotationAxis, lookAtOriginTransform, randomizationStates->getDevicePtr(), inRaysPtr, outRaysPtr);
+	gpuAddGaussianNoiseAngularRay(getStreamHandle(), getRayCount(), mean, stDev, rotationAxis, lookAtOriginTransform, randomizationStates->getDevicePtr(), inRaysPtr, outRaysPtr);
 }

--- a/src/graph/GaussianNoiseDistanceNode.cpp
+++ b/src/graph/GaussianNoiseDistanceNode.cpp
@@ -52,7 +52,7 @@ void GaussianNoiseDistanceNode::enqueueExecImpl()
 
 	if (randomizationStates->getCount() < pointCount) {
 		randomizationStates->resize(pointCount, false, false);
-		gpuSetupGaussianNoiseGenerator(nullptr, pointCount, randomDevice(), randomizationStates->getDevicePtr());
+		gpuSetupGaussianNoiseGenerator(getStreamHandle(), pointCount, randomDevice(), randomizationStates->getDevicePtr());
 	}
 
 	const auto inXyz = input->getFieldDataTyped<XYZ_F32>();

--- a/src/graph/GaussianNoiseDistanceNode.cpp
+++ b/src/graph/GaussianNoiseDistanceNode.cpp
@@ -39,7 +39,7 @@ void GaussianNoiseDistanceNode::validateImpl()
 	}
 }
 
-void GaussianNoiseDistanceNode::enqueueExecImpl(cudaStream_t stream)
+void GaussianNoiseDistanceNode::enqueueExecImpl()
 {
 	auto pointCount = input->getPointCount();
 	outXyz->resize(pointCount, false, false);
@@ -55,23 +55,23 @@ void GaussianNoiseDistanceNode::enqueueExecImpl(cudaStream_t stream)
 		gpuSetupGaussianNoiseGenerator(nullptr, pointCount, randomDevice(), randomizationStates->getDevicePtr());
 	}
 
-	const auto inXyz = input->getFieldDataTyped<XYZ_F32>(stream);
+	const auto inXyz = input->getFieldDataTyped<XYZ_F32>();
 	const auto* inXyzPtr = inXyz->getDevicePtr();
 	auto* outXyzPtr = outXyz->getDevicePtr();
-	gpuAddGaussianNoiseDistance(stream, pointCount, mean, stDevBase, stDevRisePerMeter, lookAtOriginTransform, randomizationStates->getDevicePtr(), inXyzPtr, outXyzPtr, outDistancePtr);
+	gpuAddGaussianNoiseDistance(getStreamHandle(), pointCount, mean, stDevBase, stDevRisePerMeter, lookAtOriginTransform, randomizationStates->getDevicePtr(), inXyzPtr, outXyzPtr, outDistancePtr);
 }
 
-VArray::ConstPtr GaussianNoiseDistanceNode::getFieldData(rgl_field_t field, cudaStream_t stream)
+VArray::ConstPtr GaussianNoiseDistanceNode::getFieldData(rgl_field_t field)
 {
 	if (field == XYZ_F32) {
 		// TODO(msz-rai): check synchronize is necessary
-		CHECK_CUDA(cudaStreamSynchronize(stream));
+		CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 		return outXyz->untyped();
 	}
 	if (field == DISTANCE_F32 && outDistance != nullptr) {
 		// TODO(msz-rai): check synchronize is necessary
-		CHECK_CUDA(cudaStreamSynchronize(stream));
+		CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 		return outDistance->untyped();
 	}
-	return input->getFieldData(field, stream);
+	return input->getFieldData(field);
 }

--- a/src/graph/GraphRunCtx.cpp
+++ b/src/graph/GraphRunCtx.cpp
@@ -33,6 +33,8 @@ std::shared_ptr<GraphRunCtx> GraphRunCtx::createAndAttach(std::shared_ptr<Node> 
 		currentNode->setGraphRunCtx(graphRunCtx);
 	}
 
+	GraphRunCtx::instances.push_back(graphRunCtx);
+
 	return graphRunCtx;
 }
 

--- a/src/graph/GraphRunCtx.cpp
+++ b/src/graph/GraphRunCtx.cpp
@@ -52,7 +52,7 @@ void GraphRunCtx::executeAsync()
 	for (auto&& node : executionOrder) {
 		executionStatus.try_emplace(node);
 	}
-	execThreadCanStart = false;
+	execThreadCanStart.store(false, std::memory_order_relaxed);
 
 	// TODO: this also applies to validation and executionStatus clearing
 	// In other parts of the code we rely on the following logic

--- a/src/graph/GraphRunCtx.cpp
+++ b/src/graph/GraphRunCtx.cpp
@@ -80,7 +80,7 @@ void GraphRunCtx::executeThreadMain() try
 	}
 	RGL_DEBUG("Node enqueueing done");  // This also logs the time diff for the last one
 
-	CHECK_CUDA(cudaStreamSynchronize(stream->get()));
+	CHECK_CUDA(cudaStreamSynchronize(stream->getHandle()));
 }
 catch (...)
 {
@@ -119,7 +119,7 @@ GraphRunCtx::~GraphRunCtx()
 	// If GraphRunCtx is destroyed, we expect that thread was joined and stream was synced.
 
 	// Log error if stream has pending work.
-	cudaError_t status = cudaStreamQuery(stream->get());
+	cudaError_t status = cudaStreamQuery(stream->getHandle());
 	if (status == cudaErrorNotReady) {
 		RGL_WARN("~GraphRunCtx(): stream has pending work!");
 		status = cudaSuccess; // Ignore further checks.
@@ -149,7 +149,7 @@ void GraphRunCtx::synchronize()
 	for (auto&& node : executionOrder) {
 		synchronizeNodeCPU(node);
 	}
-	CHECK_CUDA(cudaStreamSynchronize(stream->get()));
+	CHECK_CUDA(cudaStreamSynchronize(stream->getHandle()));
 	maybeThread->join();
 	maybeThread.reset();
 }

--- a/src/graph/GraphRunCtx.hpp
+++ b/src/graph/GraphRunCtx.hpp
@@ -60,7 +60,6 @@ struct GraphRunCtx
 	 */
 	void synchronizeNodeCPU(Node::Ptr nodeToSynchronize);
 
-
 	CudaStream::Ptr getStream() const { return stream; }
 	const std::set<std::shared_ptr<Node>>& getNodes() const { return nodes; }
 

--- a/src/graph/Interfaces.hpp
+++ b/src/graph/Interfaces.hpp
@@ -56,10 +56,6 @@ protected:
 	IRaysNode::Ptr input {0};
 };
 
-// TODO(prybicki): getFieldData* may act lazily, so they take stream as a parameter to do the lazy evaluation.
-// TODO(prybicki): This requires synchronizing with the potentially different stream provided by the enqueueExecImpl(...)
-// TODO(prybicki): This situation is bug-prone, requiring greater mental effort when implementing nodes.
-// TODO(prybicki): It might be better to remove stream as a parameter and assume that all pipeline nodes are using common stream.
 struct IPointsNode : virtual Node
 {
 	using Ptr = std::shared_ptr<IPointsNode>;
@@ -77,13 +73,13 @@ struct IPointsNode : virtual Node
 	virtual Mat3x4f getLookAtOriginTransform() const { return Mat3x4f::identity(); }
 
 	// Data getters
-	virtual VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) = 0;
+	virtual VArray::ConstPtr getFieldData(rgl_field_t field) = 0;
 	virtual std::size_t getFieldPointSize(rgl_field_t field) const { return getFieldSize(field); }
 
 	template<rgl_field_t field>
 	typename VArrayProxy<typename Field<field>::type>::ConstPtr
-	getFieldDataTyped(cudaStream_t stream)
-	{ return getFieldData(field, stream)->template getTypedProxy<typename Field<field>::type>(); }
+	getFieldDataTyped()
+	{ return getFieldData(field)->template getTypedProxy<typename Field<field>::type>(); }
 };
 
 struct IPointsNodeSingleInput : virtual IPointsNode
@@ -110,8 +106,8 @@ struct IPointsNodeSingleInput : virtual IPointsNode
 
 	// Data getters
 	virtual bool hasField(rgl_field_t field) const { return input->hasField(field); }
-	virtual VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override
-	{ return input->getFieldData(field, stream); }
+	virtual VArray::ConstPtr getFieldData(rgl_field_t field) override
+	{ return input->getFieldData(field); }
 
 protected:
 	IPointsNode::Ptr input {0};

--- a/src/graph/Node.cpp
+++ b/src/graph/Node.cpp
@@ -175,3 +175,8 @@ void Node::waitForResults()
 	}
 	synchronizeThis();
 }
+
+cudaStream_t Node::getStreamHandle()
+{
+	return getGraphRunCtx()->getStream()->getHandle();
+}

--- a/src/graph/Node.cpp
+++ b/src/graph/Node.cpp
@@ -117,7 +117,7 @@ void Node::enqueueExec()
 		auto msg = fmt::format("{}: attempted to call enqueueExec() despite !isValid()", getName());
 		throw std::logic_error(msg);
 	}
-	this->enqueueExecImpl(getGraphRunCtx()->getStream()->getHandle());
+	this->enqueueExecImpl();
 	CHECK_CUDA(cudaEventRecord(execCompleted->getHandle(), getGraphRunCtx()->getStream()->getHandle()));
 }
 

--- a/src/graph/Node.cpp
+++ b/src/graph/Node.cpp
@@ -117,8 +117,8 @@ void Node::enqueueExec()
 		auto msg = fmt::format("{}: attempted to call enqueueExec() despite !isValid()", getName());
 		throw std::logic_error(msg);
 	}
-	this->enqueueExecImpl(getGraphRunCtx()->getStream()->get());
-	CHECK_CUDA(cudaEventRecord(execCompleted->get(), getGraphRunCtx()->getStream()->get()));
+	this->enqueueExecImpl(getGraphRunCtx()->getStream()->getHandle());
+	CHECK_CUDA(cudaEventRecord(execCompleted->getHandle(), getGraphRunCtx()->getStream()->getHandle()));
 }
 
 std::set<Node::Ptr> Node::getConnectedNodes()
@@ -163,7 +163,7 @@ void Node::synchronizeThis()
 	// Ensure CPU execution is finished; this guarantees that execCompleted event has been recorded
 	graphRunCtx.value()->synchronizeNodeCPU(shared_from_this());
 	// Wait for all GPU operations requested by this node.
-	CHECK_CUDA(cudaEventSynchronize(execCompleted->get()));
+	CHECK_CUDA(cudaEventSynchronize(execCompleted->getHandle()));
 }
 
 void Node::waitForResults()

--- a/src/graph/Node.hpp
+++ b/src/graph/Node.hpp
@@ -194,7 +194,7 @@ public: // Static methods
 	}
 
 
-protected:
+public:
 	std::vector<Node::Ptr> inputs {};
 	std::vector<Node::Ptr> outputs {};
 

--- a/src/graph/Node.hpp
+++ b/src/graph/Node.hpp
@@ -126,7 +126,7 @@ protected: // Member methods
 	/**
 	 * Placeholder to enqueue node-specific computations in derived classes.
 	 */
-	virtual void enqueueExecImpl(cudaStream_t toBeRemoved=nullptr) = 0;
+	virtual void enqueueExecImpl() = 0;
 
 	/**
 	 * Placeholder to perform node-specific part of validation.

--- a/src/graph/Node.hpp
+++ b/src/graph/Node.hpp
@@ -145,6 +145,8 @@ protected: // Member methods
 	 */
 	void synchronizeThis();
 
+	cudaStream_t getStreamHandle();
+
 	template<typename T>
 	typename T::Ptr getExactlyOneInputOfType()
 	{ return getExactlyOneNodeOfType<T>(inputs); }

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -53,7 +53,7 @@ struct FormatPointsNode : IPointsNodeSingleInput
 	void setParameters(const std::vector<rgl_field_t>& fields);
 
 	// Node
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override { return fields; }
@@ -62,7 +62,7 @@ struct FormatPointsNode : IPointsNodeSingleInput
 	bool hasField(rgl_field_t field) const override { return std::find(fields.begin(), fields.end(), field) != fields.end(); }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override;
+	VArray::ConstPtr getFieldData(rgl_field_t field) override;
 	std::size_t getFieldPointSize(rgl_field_t field) const override;
 
 	// Actual implementation of formatting made public for other nodes
@@ -72,8 +72,7 @@ struct FormatPointsNode : IPointsNodeSingleInput
 
 private:
 	static std::vector<std::pair<rgl_field_t, const void*>> getFieldToPointerMappings(const IPointsNode::Ptr& input,
-	                                                                                  const std::vector<rgl_field_t>& fields,
-	                                                                                  cudaStream_t stream);
+	                                                                                  const std::vector<rgl_field_t>& fields);
 
 	std::vector<rgl_field_t> fields;
 	VArray::Ptr output = VArray::create<char>();
@@ -89,7 +88,7 @@ struct CompactPointsNode : IPointsNodeSingleInput
 	virtual ~CompactPointsNode() { CHECK_CUDA_NO_THROW(cudaEventDestroy(finishedEvent)); }
 
 	// Node
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override { return {IS_HIT_I32}; }
@@ -100,7 +99,7 @@ struct CompactPointsNode : IPointsNodeSingleInput
 	size_t getHeight() const override { return 1; }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override;
+	VArray::ConstPtr getFieldData(rgl_field_t field) override;
 
 private:
 	size_t width = {0};
@@ -116,7 +115,7 @@ struct RaytraceNode : IPointsNode
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Point cloud description
 	bool isDense() const override { return false; }
@@ -127,7 +126,7 @@ struct RaytraceNode : IPointsNode
 	Mat3x4f getLookAtOriginTransform() const override { return raysNode->getCumulativeRayTransfrom().inverse(); }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override
+	VArray::ConstPtr getFieldData(rgl_field_t field) override
 	{ return std::const_pointer_cast<const VArray>(fieldData.at(field)); }
 
 private:
@@ -151,7 +150,7 @@ struct TransformPointsNode : IPointsNodeSingleInput
 	Mat3x4f getTransform() const { return transform; }
 
 	// Node
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 	std::string getArgsString() const override;
 
 	// Node requirements
@@ -160,7 +159,7 @@ struct TransformPointsNode : IPointsNodeSingleInput
 	Mat3x4f getLookAtOriginTransform() const override { return transform.inverse() * input->getLookAtOriginTransform(); }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override;
+	VArray::ConstPtr getFieldData(rgl_field_t field) override;
 
 private:
 	Mat3x4f transform;
@@ -173,7 +172,7 @@ struct TransformRaysNode : IRaysNodeSingleInput
 	void setParameters(Mat3x4f transform) { this->transform = transform; }
 
 	// Node
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Data getters
 	VArrayProxy<Mat3x4f>::ConstPtr getRays() const override { return rays; }
@@ -190,7 +189,7 @@ struct FromMat3x4fRaysNode : virtual IRaysNode, virtual INoInputNode
 	void setParameters(const Mat3x4f* raysRaw, size_t rayCount);
 
 	// Node
-	void enqueueExecImpl(cudaStream_t stream) override {}
+	void enqueueExecImpl() override {}
 
 	// Rays description
 	size_t getRayCount() const override { return rays->getCount(); }
@@ -211,7 +210,7 @@ struct SetRingIdsRaysNode : IRaysNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override {}
+	void enqueueExecImpl() override {}
 
 	// Rays description
 	std::optional<size_t> getRingIdsCount() const override { return ringIds->getCount(); }
@@ -229,13 +228,13 @@ struct YieldPointsNode : IPointsNodeSingleInput
 	void setParameters(const std::vector<rgl_field_t>& fields);
 
 	// Node
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override { return fields; }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override
+	VArray::ConstPtr getFieldData(rgl_field_t field) override
 	{ return results.at(field); }
 
 private:
@@ -250,7 +249,7 @@ struct SpatialMergePointsNode : IPointsNode
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override
@@ -263,7 +262,7 @@ struct SpatialMergePointsNode : IPointsNode
 	std::size_t getHeight() const override { return 1; }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override
+	VArray::ConstPtr getFieldData(rgl_field_t field) override
 	{ return std::const_pointer_cast<const VArray>(mergedData.at(field)); }
 
 private:
@@ -279,7 +278,7 @@ struct TemporalMergePointsNode : IPointsNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override
@@ -290,7 +289,7 @@ struct TemporalMergePointsNode : IPointsNodeSingleInput
 	std::size_t getWidth() const override { return width; }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override
+	VArray::ConstPtr getFieldData(rgl_field_t field) override
 	{ return std::const_pointer_cast<const VArray>(mergedData.at(field)); }
 
 private:
@@ -304,7 +303,7 @@ struct FromArrayPointsNode : IPointsNode, INoInputNode
 	void setParameters(const void* points, size_t pointCount, const std::vector<rgl_field_t>& fields);
 
 	// Node
-	void enqueueExecImpl(cudaStream_t stream) override {}
+	void enqueueExecImpl() override {}
 
 	// Point cloud description
 	bool isDense() const override { return false; }
@@ -313,7 +312,7 @@ struct FromArrayPointsNode : IPointsNode, INoInputNode
 	size_t getHeight() const override { return 1; }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override
+	VArray::ConstPtr getFieldData(rgl_field_t field) override
 	{ return std::const_pointer_cast<const VArray>(fieldData.at(field)); }
 
 private:
@@ -332,7 +331,7 @@ struct GaussianNoiseAngularRaysNode : IRaysNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Data getters
 	VArrayProxy<Mat3x4f>::ConstPtr getRays() const override { return rays; }
@@ -356,13 +355,13 @@ struct GaussianNoiseAngularHitpointNode : IPointsNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override { return {XYZ_F32}; }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override;
+	VArray::ConstPtr getFieldData(rgl_field_t field) override;
 
 private:
 	float mean;
@@ -384,13 +383,13 @@ struct GaussianNoiseDistanceNode : IPointsNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override { return {XYZ_F32}; };
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override;
+	VArray::ConstPtr getFieldData(rgl_field_t field) override;
 
 private:
 	float mean;

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -125,10 +125,6 @@ struct RaytraceNode : IPointsNode
 
 	Mat3x4f getLookAtOriginTransform() const override { return raysNode->getCumulativeRayTransfrom().inverse(); }
 
-	int getHitCount();
-
-	void* getFieldDataHost(rgl_field_t);
-
 	// Data getters
 	VArray::ConstPtr getFieldData(rgl_field_t field) override
 	{ return std::const_pointer_cast<const VArray>(fieldData.at(field)); }

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -125,6 +125,10 @@ struct RaytraceNode : IPointsNode
 
 	Mat3x4f getLookAtOriginTransform() const override { return raysNode->getCumulativeRayTransfrom().inverse(); }
 
+	int getHitCount();
+
+	void* getFieldDataHost(rgl_field_t);
+
 	// Data getters
 	VArray::ConstPtr getFieldData(rgl_field_t field) override
 	{ return std::const_pointer_cast<const VArray>(fieldData.at(field)); }

--- a/src/graph/NodesPcl.hpp
+++ b/src/graph/NodesPcl.hpp
@@ -34,7 +34,7 @@ struct DownSamplePointsNode : IPointsNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override;
@@ -45,7 +45,7 @@ struct DownSamplePointsNode : IPointsNodeSingleInput
 	size_t getHeight() const override { return 1; }
 
 	// Data getters
-	VArray::ConstPtr getFieldData(rgl_field_t field, cudaStream_t stream) override;
+	VArray::ConstPtr getFieldData(rgl_field_t field) override;
 
 
 
@@ -68,7 +68,7 @@ struct VisualizePointsNode : IPointsNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override;

--- a/src/graph/NodesRos2.hpp
+++ b/src/graph/NodesRos2.hpp
@@ -37,7 +37,7 @@ struct Ros2PublishPointsNode : IPointsNodeSingleInput
 
 	// Node
 	void validateImpl() override;
-	void enqueueExecImpl(cudaStream_t stream) override;
+	void enqueueExecImpl() override;
 
 	~Ros2PublishPointsNode();
 

--- a/src/graph/RaytraceNode.cpp
+++ b/src/graph/RaytraceNode.cpp
@@ -82,6 +82,22 @@ void RaytraceNode::enqueueExecImpl()
 	CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 }
 
+int RaytraceNode::getHitCount()
+{
+	int hitCount = 0;
+	const int* isHit = fieldData.at(RGL_FIELD_IS_HIT_I32)->getTypedProxy<int32_t>()->getReadPtr(MemLoc::Host);
+	for (int i = 0; i < raysNode->getRayCount(); ++i) {
+		hitCount += isHit[i];
+	}
+	return hitCount;
+}
+
+void *RaytraceNode::getFieldDataHost(rgl_field_t field)
+{
+	return fieldData.at(field)->getWritePtr(MemLoc::Host);
+}
+
+
 void RaytraceNode::setFields(const std::set<rgl_field_t>& fields)
 {
 	auto keyViewer = std::views::keys(fieldData);
@@ -126,3 +142,4 @@ std::set<rgl_field_t> RaytraceNode::findFieldsToCompute()
 
 	return outFields;
 }
+

--- a/src/graph/RaytraceNode.cpp
+++ b/src/graph/RaytraceNode.cpp
@@ -82,22 +82,6 @@ void RaytraceNode::enqueueExecImpl()
 	CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 }
 
-int RaytraceNode::getHitCount()
-{
-	int hitCount = 0;
-	const int* isHit = fieldData.at(RGL_FIELD_IS_HIT_I32)->getTypedProxy<int32_t>()->getReadPtr(MemLoc::Host);
-	for (int i = 0; i < raysNode->getRayCount(); ++i) {
-		hitCount += isHit[i];
-	}
-	return hitCount;
-}
-
-void *RaytraceNode::getFieldDataHost(rgl_field_t field)
-{
-	return fieldData.at(field)->getWritePtr(MemLoc::Host);
-}
-
-
 void RaytraceNode::setFields(const std::set<rgl_field_t>& fields)
 {
 	auto keyViewer = std::views::keys(fieldData);

--- a/src/graph/RaytraceNode.cpp
+++ b/src/graph/RaytraceNode.cpp
@@ -44,7 +44,7 @@ auto RaytraceNode::getPtrTo()
 	return fieldData.contains(field) ? fieldData.at(field)->getTypedProxy<typename Field<field>::type>()->getDevicePtr() : nullptr;
 }
 
-void RaytraceNode::enqueueExecImpl(cudaStream_t stream)
+void RaytraceNode::enqueueExecImpl()
 {
 	for (auto const& [_, data] : fieldData) {
 		data->resize(raysNode->getRayCount(), false, false);
@@ -78,8 +78,8 @@ void RaytraceNode::enqueueExecImpl(cudaStream_t stream)
 
 	CUdeviceptr pipelineArgsPtr = requestCtx->getCUdeviceptr();
 	std::size_t pipelineArgsSize = requestCtx->getBytesInUse();
-	CHECK_OPTIX(optixLaunch(Optix::getOrCreate().pipeline, stream, pipelineArgsPtr, pipelineArgsSize, &sceneSBT, launchDims.x, launchDims.y, launchDims.y));
-	CHECK_CUDA(cudaStreamSynchronize(stream));
+	CHECK_OPTIX(optixLaunch(Optix::getOrCreate().pipeline, getStreamHandle(), pipelineArgsPtr, pipelineArgsSize, &sceneSBT, launchDims.x, launchDims.y, launchDims.y));
+	CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 }
 
 void RaytraceNode::setFields(const std::set<rgl_field_t>& fields)

--- a/src/graph/Ros2PublishPointsNode.cpp
+++ b/src/graph/Ros2PublishPointsNode.cpp
@@ -63,9 +63,9 @@ void Ros2PublishPointsNode::validateImpl()
 	updateRos2Message(input->getRequiredFieldList(), input->isDense());
 }
 
-void Ros2PublishPointsNode::enqueueExecImpl(cudaStream_t stream)
+void Ros2PublishPointsNode::enqueueExecImpl()
 {
-	auto fieldData = input->getFieldData(RGL_FIELD_DYNAMIC_FORMAT, stream);
+	auto fieldData = input->getFieldData(RGL_FIELD_DYNAMIC_FORMAT);
 	int count = input->getPointCount();
 	ros2Message.data.resize(ros2Message.point_step * count);
 	fieldData->getData(ros2Message.data.data(), ros2Message.point_step * count);

--- a/src/graph/SpatialMergePointsNode.cpp
+++ b/src/graph/SpatialMergePointsNode.cpp
@@ -58,7 +58,7 @@ void SpatialMergePointsNode::validateImpl()
 	}
 }
 
-void SpatialMergePointsNode::enqueueExecImpl(cudaStream_t stream)
+void SpatialMergePointsNode::enqueueExecImpl()
 {
 	width = 0;
 	for (const auto& input : pointInputs) {
@@ -71,7 +71,7 @@ void SpatialMergePointsNode::enqueueExecImpl(cudaStream_t stream)
 		size_t offset = 0;
 		for (const auto& input : pointInputs) {
 			size_t pointCount = input->getPointCount();
-			const auto toMergeData = input->getFieldData(field, stream);
+			const auto toMergeData = input->getFieldData(field);
 			data->insertData(toMergeData->getReadPtr(MemLoc::Device), pointCount, offset);
 			offset += pointCount;
 		}

--- a/src/graph/TemporalMergePointsNode.cpp
+++ b/src/graph/TemporalMergePointsNode.cpp
@@ -45,12 +45,12 @@ void TemporalMergePointsNode::validateImpl()
 	}
 }
 
-void TemporalMergePointsNode::enqueueExecImpl(cudaStream_t stream)
+void TemporalMergePointsNode::enqueueExecImpl()
 {
 	// This could work lazily - merging only on demand
 	for (const auto& [field, data] : mergedData) {
 		size_t pointCount = input->getPointCount();
-		const auto toMergeData = input->getFieldData(field, stream);
+		const auto toMergeData = input->getFieldData(field);
 		data->insertData(toMergeData->getReadPtr(MemLoc::Device), pointCount, width);
 	}
 	width += input->getWidth();

--- a/src/graph/TransformPointsNode.cpp
+++ b/src/graph/TransformPointsNode.cpp
@@ -23,13 +23,25 @@ void TransformPointsNode::enqueueExecImpl()
 	const auto* inputPtr = inputField->getDevicePtr();
 	auto* outputPtr = output->getDevicePtr();
 	gpuTransformPoints(getStreamHandle(), pointCount, inputPtr, outputPtr, transform);
+
+	// TODO: what the hell is happening here? output is wrong when EXPECT_ is executed; must be somewhere in the computation
+	// BAD INPUT?
+
+	CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
+	const Vec3f* ptr = output->getReadPtr(MemLoc::Host);
+	std::vector asdf(ptr, ptr + output->getCount());
+	for (int i = 1; i < asdf.size(); ++i) {
+		auto&& a = asdf[i];
+		if (a.x() == 0 || a.y() == 0 || a.z() == 0) {
+			return;
+		}
+	}
 }
 
 VArray::ConstPtr TransformPointsNode::getFieldData(rgl_field_t field)
 {
 	if (field == XYZ_F32) {
 		// TODO(prybicki): check synchronize is necessary
-		CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 		return output->untyped();
 	}
 	return input->getFieldData(field);
@@ -39,4 +51,12 @@ VArray::ConstPtr TransformPointsNode::getFieldData(rgl_field_t field)
 std::string TransformPointsNode::getArgsString() const
 {
 	return fmt::format("TR={}", transform.translation());
+}
+
+void magic(Vec3f* ptr, size_t count)
+{
+	std::vector<Vec3f> vec;
+	vec.resize(count);
+	CHECK_CUDA(cudaMemcpy(vec.data(), ptr, count * sizeof(Vec3f), cudaMemcpyDeviceToHost));
+	return;
 }

--- a/src/graph/TransformPointsNode.cpp
+++ b/src/graph/TransformPointsNode.cpp
@@ -15,24 +15,24 @@
 #include <graph/NodesCore.hpp>
 #include <gpu/nodeKernels.hpp>
 
-void TransformPointsNode::enqueueExecImpl(cudaStream_t stream)
+void TransformPointsNode::enqueueExecImpl()
 {
 	auto pointCount = input->getWidth() * input->getHeight();
 	output->resize(pointCount);
-	const auto inputField = input->getFieldDataTyped<XYZ_F32>(stream);
+	const auto inputField = input->getFieldDataTyped<XYZ_F32>();
 	const auto* inputPtr = inputField->getDevicePtr();
 	auto* outputPtr = output->getDevicePtr();
-	gpuTransformPoints(stream, pointCount, inputPtr, outputPtr, transform);
+	gpuTransformPoints(getStreamHandle(), pointCount, inputPtr, outputPtr, transform);
 }
 
-VArray::ConstPtr TransformPointsNode::getFieldData(rgl_field_t field, cudaStream_t stream)
+VArray::ConstPtr TransformPointsNode::getFieldData(rgl_field_t field)
 {
 	if (field == XYZ_F32) {
 		// TODO(prybicki): check synchronize is necessary
-		CHECK_CUDA(cudaStreamSynchronize(stream));
+		CHECK_CUDA(cudaStreamSynchronize(getStreamHandle()));
 		return output->untyped();
 	}
-	return input->getFieldData(field, stream);
+	return input->getFieldData(field);
 }
 
 

--- a/src/graph/TransformRaysNode.cpp
+++ b/src/graph/TransformRaysNode.cpp
@@ -15,8 +15,8 @@
 #include <graph/NodesCore.hpp>
 #include <gpu/nodeKernels.hpp>
 
-void TransformRaysNode::enqueueExecImpl(cudaStream_t stream)
+void TransformRaysNode::enqueueExecImpl()
 {
 	rays->resize(getRayCount());
-	gpuTransformRays(stream, getRayCount(), input->getRays()->getDevicePtr(), rays->getDevicePtr(), transform);
+	gpuTransformRays(getStreamHandle(), getRayCount(), input->getRays()->getDevicePtr(), rays->getDevicePtr(), transform);
 }

--- a/src/graph/VisualizePointsNode.cpp
+++ b/src/graph/VisualizePointsNode.cpp
@@ -69,14 +69,14 @@ void VisualizePointsNode::runVisualize()
 	}
 }
 
-void VisualizePointsNode::enqueueExecImpl(cudaStream_t stream)
+void VisualizePointsNode::enqueueExecImpl()
 {
 	if (input->getPointCount() == 0) {
 		return;
 	}
 
 	// Get formatted input data
-	FormatPointsNode::formatAsync(inputFmtData, input, getRequiredFieldList(), stream, gpuFieldDescBuilder);
+	FormatPointsNode::formatAsync(inputFmtData, input, getRequiredFieldList(), getStreamHandle(), gpuFieldDescBuilder);
 
 	// Convert to PCL cloud
 	const PCLPointType * data = reinterpret_cast<const PCLPointType*>(inputFmtData->getReadPtr(MemLoc::Host));

--- a/src/graph/YieldPointsNode.cpp
+++ b/src/graph/YieldPointsNode.cpp
@@ -22,10 +22,10 @@ void YieldPointsNode::setParameters(const std::vector<rgl_field_t>& fields)
 	this->fields = fields;
 }
 
-void YieldPointsNode::enqueueExecImpl(cudaStream_t stream)
+void YieldPointsNode::enqueueExecImpl()
 {
 	for (auto&& field : fields) {
-		results[field] = input->getFieldData(field, stream);
+		results[field] = input->getFieldData(field);
 	}
 }
 

--- a/src/macros/cuda.hpp
+++ b/src/macros/cuda.hpp
@@ -18,19 +18,19 @@
 
 #include <spdlog/fmt/fmt.h>
 
-static inline void onCUDAError() {}
+static void onCUDAError() {}
 
 #define CHECK_CUDA(call)                                                                            \
 do                                                                                                  \
 {                                                                                                   \
     cudaError_t errCode = call;                                                                     \
-    if (errCode == cudaErrorCudartUnloading) {                                                      \
-        break;                                                                                      \
-    }                                                                                               \
     if (errCode != cudaSuccess) {                                                                   \
-        auto message = fmt::format("cuda error: {} (code={}) @ {}:{}",                              \
-        cudaGetErrorString(errCode), errCode, __FILE__, __LINE__);                                  \
         onCUDAError();                                                                              \
+        if (errCode == cudaErrorCudartUnloading) {                                                  \
+            break;                                                                                  \
+        }                                                                                           \
+        auto message = fmt::format("cuda error: {} (code={}) @ {}:{}",                              \
+                                   cudaGetErrorString(errCode), errCode, __FILE__, __LINE__);       \
         throw std::runtime_error(message);                                                          \
     }                                                                                               \
 }                                                                                                   \

--- a/src/memory/DeviceAsyncArray.hpp
+++ b/src/memory/DeviceAsyncArray.hpp
@@ -45,8 +45,8 @@ struct DeviceAsyncArray : public DeviceArray<MemoryKind::DeviceAsync, T>, public
 	void copyFrom(HostPinnedArray<T>::Ptr src)
 	{
 		this->resize(src->getCount(), false, false);
-		CHECK_CUDA(cudaMemcpyAsync(this->data, src->data, this->getSizeOf() * this->getCount(), cudaMemcpyHostToDevice, this->getStream()->get()));
-		CHECK_CUDA(cudaStreamSynchronize(this->getStream()->get()));
+		CHECK_CUDA(cudaMemcpyAsync(this->data, src->data, this->getSizeOf() * this->getCount(), cudaMemcpyHostToDevice, this->getStream()->getHandle()));
+		CHECK_CUDA(cudaStreamSynchronize(this->getStream()->getHandle()));
 	}
 
 	static DeviceAsyncArray<T>::Ptr createWithManager(StreamBoundObjectsManager& manager)

--- a/src/memory/HostPinnedArray.hpp
+++ b/src/memory/HostPinnedArray.hpp
@@ -34,8 +34,9 @@ struct HostPinnedArray : public HostArray<MemoryKind::HostPinned, T>
 	void copyFrom(DeviceAsyncArray<T>::Ptr source)
 	{
 		this->resize(source->getCount(), false, false);
-		CHECK_CUDA(cudaMemcpyAsync(this->data, source->data, this->getSizeOf() * this->getCount(), cudaMemcpyDeviceToHost, source->getStream()->get()));
-		CHECK_CUDA(cudaStreamSynchronize(source->getStream()->get()));
+		CHECK_CUDA(cudaMemcpyAsync(this->data, source->data, this->getSizeOf() * this->getCount(), cudaMemcpyDeviceToHost,
+		                           source->getStream()->getHandle()));
+		CHECK_CUDA(cudaStreamSynchronize(source->getStream()->getHandle()));
 	}
 
 protected:

--- a/src/memory/MemoryOperations.hpp
+++ b/src/memory/MemoryOperations.hpp
@@ -82,17 +82,17 @@ struct MemoryOperations
 				// Note: capture-by-value to ensure CudaStream lifetime.
 				.allocate = [=](size_t bytes) {
 					void* ptr = nullptr;
-					CHECK_CUDA(cudaMallocAsync(&ptr, bytes, stream->get()));
+					CHECK_CUDA(cudaMallocAsync(&ptr, bytes, stream->getHandle()));
 					return ptr;
 				},
 				.deallocate = [=](void* ptr) {
-					CHECK_CUDA(cudaFreeAsync(ptr, stream->get()));
+					CHECK_CUDA(cudaFreeAsync(ptr, stream->getHandle()));
 				},
 				.copy = [=](void* dst, const void* src, size_t bytes) {
-					CHECK_CUDA(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToDevice, stream->get()));
+					CHECK_CUDA(cudaMemcpyAsync(dst, src, bytes, cudaMemcpyDeviceToDevice, stream->getHandle()));
 				},
 				.clear = [=](void* dst, int value, size_t bytes) {
-					CHECK_CUDA(cudaMemsetAsync(dst, value, bytes, stream->get()));
+					CHECK_CUDA(cudaMemsetAsync(dst, value, bytes, stream->getHandle()));
 				}
 			};
 		}

--- a/src/scene/Entity.cpp
+++ b/src/scene/Entity.cpp
@@ -37,7 +37,7 @@ OptixInstance Entity::getIAS(int idx)
 		.sbtOffset = static_cast<unsigned int>(idx),
 		.visibilityMask = 255,
 		.flags = OPTIX_INSTANCE_FLAG_DISABLE_ANYHIT,
-		.traversableHandle = mesh->getGAS(),
+		.traversableHandle = mesh->getGAS(scene.lock()->getStream()),
 	};
 	transform.toRaw(instance.transform);
 	return instance;

--- a/src/scene/Mesh.hpp
+++ b/src/scene/Mesh.hpp
@@ -28,18 +28,31 @@
 #include <filesystem>
 #include <memory/DeviceSyncArray.hpp>
 
-
+/**
+ * Represents mesh data (at the moment vertices and indices) stored on the GPU.
+ * Mesh, on its own, is not bound to any scene and can be used for different scenes.
+ */
 struct Mesh : APIObject<Mesh>
 {
+	/**
+	 * Updates vertices of this mesh. Vertex count must remain unchanged, otherwise an exception is thrown.
+	 * After this operation, GAS needs to be rebuilt. This is handled internally in getGAS.
+	 */
 	void updateVertices(const Vec3f *vertices, std::size_t vertexCount);
-	OptixTraversableHandle getGAS();
+
+	/**
+	 * Returns GAS for this mesh.
+	 * If no changes occurred (e.g. call to updateVertices), then returns cached GAS.
+	 * Otherwise, queues building GAS in the given stream, without synchronizing it.
+	 */
+	OptixTraversableHandle getGAS(CudaStream::Ptr stream);
 
 private:
 	Mesh(const Vec3f *vertices, std::size_t vertexCount,
 		 const Vec3i *indices, std::size_t indexCount);
 
-	OptixTraversableHandle buildGAS();
-	void updateGAS();
+	OptixTraversableHandle buildGAS(CudaStream::Ptr stream);
+	void updateGAS(CudaStream::Ptr stream);
 
 private:
 	friend APIObject<Mesh>;

--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -188,4 +188,9 @@ void Scene::requestSBTRebuild()
 	cachedSBT.reset();
 }
 
+CudaStream::Ptr Scene::getStream()
+{
+	return stream;
+}
+
 

--- a/src/scene/Scene.cpp
+++ b/src/scene/Scene.cpp
@@ -25,6 +25,8 @@ std::shared_ptr<Scene> Scene::defaultInstance()
 	return scene;
 }
 
+Scene::Scene() : stream(CudaStream::create(cudaStreamNonBlocking)) { }
+
 std::size_t Scene::getObjectCount()
 { return entities.size(); }
 
@@ -156,7 +158,7 @@ OptixTraversableHandle Scene::buildAS()
 
 	OptixTraversableHandle sceneHandle;
 	CHECK_OPTIX(optixAccelBuild(Optix::getOrCreate().context,
-	                            nullptr, // TODO(prybicki): run in stream
+	                            stream->getHandle(),
 	                            &accelBuildOptions,
 	                            &instanceInput,
 	                            1,
@@ -168,6 +170,8 @@ OptixTraversableHandle Scene::buildAS()
 	                            &emitDesc,
 	                            1
 	));
+
+	CHECK_CUDA(cudaStreamSynchronize(stream->getHandle()));
 
 	// scratchpad.doCompaction(sceneHandle);
 
@@ -183,3 +187,5 @@ void Scene::requestSBTRebuild()
 {
 	cachedSBT.reset();
 }
+
+

--- a/src/scene/Scene.hpp
+++ b/src/scene/Scene.hpp
@@ -45,6 +45,8 @@ struct Scene : APIObject<Scene>, std::enable_shared_from_this<Scene>
 {
 	static std::shared_ptr<Scene> defaultInstance();
 
+	Scene();
+
 	void addEntity(std::shared_ptr<Entity> entity);
 	void removeEntity(std::shared_ptr<Entity> entity);
 	void clear();
@@ -66,6 +68,7 @@ private:
 	OptixTraversableHandle buildAS();
 
 private:
+	CudaStream::Ptr stream;
 	std::set<std::shared_ptr<Entity>> entities;
 	ASBuildScratchpad scratchpad;
 

--- a/src/scene/Scene.hpp
+++ b/src/scene/Scene.hpp
@@ -56,6 +56,7 @@ struct Scene : APIObject<Scene>, std::enable_shared_from_this<Scene>
 
 	std::size_t getObjectCount();
 
+	CudaStream::Ptr getStream();
 	OptixTraversableHandle getAS();
 	OptixShaderBindingTable getSBT();
 

--- a/test/include/utils.hpp
+++ b/test/include/utils.hpp
@@ -48,7 +48,7 @@ struct RGLTest : public ::testing::Test {
 protected:
 	RGLTest()
 	{
-		rgl_configure_logging(RGL_LOG_LEVEL_WARN, nullptr, true);
+		rgl_configure_logging(RGL_LOG_LEVEL_OFF, nullptr, true);
 	}
 
     virtual ~RGLTest() override

--- a/test/include/utils.hpp
+++ b/test/include/utils.hpp
@@ -48,7 +48,7 @@ struct RGLTest : public ::testing::Test {
 protected:
 	RGLTest()
 	{
-		rgl_configure_logging(RGL_LOG_LEVEL_OFF, nullptr, false);
+		rgl_configure_logging(RGL_LOG_LEVEL_WARN, nullptr, true);
 	}
 
     virtual ~RGLTest() override

--- a/test/src/asyncStressTest.cpp
+++ b/test/src/asyncStressTest.cpp
@@ -14,7 +14,7 @@ const Vec3f cubePosition = {0, 0, 5};
 const Vec3f cubeDims = {2, 2, 2};
 
 static std::random_device randomDevice;
-static auto randomSeed = randomDevice();
+static auto randomSeed = 3161367471; //randomDevice();
 static std::mt19937 randomGenerator {randomSeed};
 
 // randomizeIndices(10,3): 9, 0, 5
@@ -195,8 +195,7 @@ TEST_F(GraphStress, Async)
 		// Iterate over graphs and check a single node at a time.
 		// Repeat until all graphs are checked (each node from run.nodeCheckOrder is checked)
 		bool allGraphsChecked = false;
-		while (!allGraphsChecked)
-		{
+		while (!allGraphsChecked) {
 			allGraphsChecked = true; // This will be and-ed with is-checked for all graphs
 
 			// Check a single node from each graph

--- a/test/src/asyncStressTest.cpp
+++ b/test/src/asyncStressTest.cpp
@@ -14,7 +14,7 @@ const Vec3f cubePosition = {0, 0, 5};
 const Vec3f cubeDims = {2, 2, 2};
 
 static std::random_device randomDevice;
-static auto randomSeed = 3161367471; //randomDevice();
+static auto randomSeed = randomDevice();
 static std::mt19937 randomGenerator {randomSeed};
 
 // randomizeIndices(10,3): 9, 0, 5

--- a/test/src/memory/arrayChangeStreamTest.cpp
+++ b/test/src/memory/arrayChangeStreamTest.cpp
@@ -64,7 +64,7 @@ TEST_F(ArrayChangeStream, Standalone)
 	array->copyFrom(nonZeroIntPattern); // Synchronizes array's stream.
 
 	// Block streamA. This way, scheduled operations will be not executed.
-	CHECK_CUDA(cudaStreamAddCallback(streamA->get(), waitCb, &shouldSleep, 0));
+	CHECK_CUDA(cudaStreamAddCallback(streamA->getHandle(), waitCb, &shouldSleep, 0));
 
 	// Change array's stream.
 	array->setStream(streamB);
@@ -95,7 +95,7 @@ TEST_F(ArrayChangeStream, WithManager)
 	arrayC.reset();
 
 	// Block streamA. This way, scheduled operations will be not executed.
-	CHECK_CUDA(cudaStreamAddCallback(streamA->get(), waitCb, &shouldSleep, 0));
+	CHECK_CUDA(cudaStreamAddCallback(streamA->getHandle(), waitCb, &shouldSleep, 0));
 
 	// Provide a new stream for arrays.
 	arrayMgr.setStream(streamB);

--- a/test/src/synchronization/graphAndCopyStream.cpp
+++ b/test/src/synchronization/graphAndCopyStream.cpp
@@ -50,7 +50,7 @@ TEST(Synchronization, GraphAndCopyStream)
     testKernelWrapper(maxGPUCoresTestCount, deviceArray, graphStream);
 
     // Record synchronization event to the stream after sensitive job.
-    CHECK_CUDA(cudaEventRecord(jobDoneEvent->get(), graphStream));
+    CHECK_CUDA(cudaEventRecord(jobDoneEvent->getHandle(), graphStream));
 
     // Perform copy operation on the copyStream parallel to graphStream kernel.
     float* dummyDeviceArray;
@@ -60,7 +60,7 @@ TEST(Synchronization, GraphAndCopyStream)
 
     // Synchronize streams. This is pass or not for the test.
     //  All API Calls in given stream, will wait for the event  to be completed.
-    CHECK_CUDA(cudaStreamWaitEvent(copyStream, jobDoneEvent->get()));
+    CHECK_CUDA(cudaStreamWaitEvent(copyStream, jobDoneEvent->getHandle()));
 
     // Copy result from device memory to host memory by substream
     // cudaMemcpy(hostArray, deviceArray, size, cudaMemcpyDeviceToHost);


### PR DESCRIPTION
This PR contains mostly mundane refactoring to remove the passing stream to Node::executeImpl and use the stream from the bound GraphRunCtx.
It adds explicit syncs in VArray (to be removed...) to pass tests.