### PR TITLE
Fix getting optional scene time

### DIFF
--- a/src/graph/RaytraceNode.cpp
+++ b/src/graph/RaytraceNode.cpp
@@ -64,7 +64,7 @@ void RaytraceNode::schedule(cudaStream_t stream)
 		.ringIds = ringIds.has_value() ? (*ringIds)->getDevicePtr() : nullptr,
 		.ringIdsCount = ringIds.has_value() ? (*ringIds)->getCount() : 0,
 		.scene = sceneAS,
-		.sceneTime = scene->getTime()->asSeconds(),
+		.sceneTime = scene->getTime().has_value() ? scene->getTime()->asSeconds() : 0,
 		.xyz = getPtrTo<XYZ_F32>(),
 		.isHit = getPtrTo<IS_HIT_I32>(),
 		.rayIdx = getPtrTo<RAY_IDX_U32>(),


### PR DESCRIPTION
Scene time is an optional field. It must be checked if the value had been set before getting it.