### PR TITLE
Fix ROS2 initialization

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 FetchContent_Declare(
     spdlog
     GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.10.0
+    GIT_TAG v1.9.2
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(spdlog)

--- a/src/graph/NodesRos2.hpp
+++ b/src/graph/NodesRos2.hpp
@@ -50,6 +50,7 @@ private:
 	rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr ros2Publisher;
 	sensor_msgs::msg::PointCloud2 ros2Message;
 
+	static bool isRclcppInitializedByRGL;
 	static rclcpp::Node::SharedPtr ros2Node;
 	static std::string ros2NodeName;
 	static std::set<std::string> ros2TopicNames;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 set(RGL_TEST_FILES
+        src/externalLibraryTest.cpp
         src/graphTest.cpp
         src/apiReadmeExample.cpp
         src/gaussianStressTest.cpp

--- a/test/src/externalLibraryTest.cpp
+++ b/test/src/externalLibraryTest.cpp
@@ -8,7 +8,9 @@
 
 class ExternalLibraryTest : public RGLTest {};
 
-#if RGL_BUILD_ROS2_EXTENSION
+// TODO (msz-rai): Make it work on Windows.
+//  Currently, there is a bug when destroying Optix on Windows which causes non-zero exit code.
+#if RGL_BUILD_ROS2_EXTENSION && __GNUC__
 /**
  * rclcpp library (part of the ROS2 extension) depends on spdlog library.
  * RGL also uses spdlog for logging purposes.

--- a/test/src/externalLibraryTest.cpp
+++ b/test/src/externalLibraryTest.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include <gtest/gtest-death-test.h>
+#include <utils.hpp>
+
+#if RGL_BUILD_ROS2_EXTENSION
+#include <rgl/api/extensions/ros2.h>
+#endif
+
+class ExternalLibraryTest : public RGLTest {};
+
+#if RGL_BUILD_ROS2_EXTENSION
+/**
+ * rclcpp library (part of the ROS2 extension) depends on spdlog library.
+ * RGL also uses spdlog for logging purposes.
+ * Using RGL with rclcpp causes an error (segmentation fault)
+ * when the version of spdlog with which libraries (RGL and rclcpp) were built differs.
+ *
+ * This test checks if rclcpp initializes and shuts down properly.
+ * rclcpp is initialized when creating the first `rgl_node_points_ros2_publish` node,
+ * and shut down when destroying the last of the `rgl_node_points_ros2_publish` nodes.
+ */
+TEST_F(ExternalLibraryTest, RclcppInitializeAndShutDownProperly)
+{
+	::testing::GTEST_FLAG(death_test_style) = "threadsafe";
+	ASSERT_EXIT({
+		rgl_node_t ros2pub = nullptr;
+		rgl_node_points_ros2_publish(&ros2pub, "rglTopic", "rglFrame");
+		rgl_cleanup();
+		exit(0);
+	}, ::testing::ExitedWithCode(0), "")
+		<< "Test for rclcpp (de)initialization failed. "
+		<< "It is probably caused by a mismatched version of the spdlog library for RGL and ROS2. "
+		<< "Check its compatibility.";
+}
+#endif


### PR DESCRIPTION
Before this PR, ROS2 was always initialized by RGL. It causes an error when using RGL in the C++ plugins (they run RGL in the same process), which also initializes ROS2 (ROS2 was initialized twice).
Now, RGL is checking whether ROS2 is already initialized.

Also, a logging conflict between ROS2 and RGL was resolved. It was needed to match the version of spdlog for both libraries. A test was created to validate the proper initialization and shutdown of ROS2.