### PR TITLE
Fix regex to match the multi-digital standalone library versions

### DIFF
--- a/ros2_standalone/CMakeLists.txt
+++ b/ros2_standalone/CMakeLists.txt
@@ -135,7 +135,7 @@ endmacro()
 # Install all libraries listed in REQ_STANDALONE_LIBS
 macro(install_standalone_dependencies)
     # Filter valid libraries
-    list(FILTER REQ_STANDALONE_LIBS INCLUDE REGEX ".*(lib|dll|so)(\.[0-9])*$")
+    list(FILTER REQ_STANDALONE_LIBS INCLUDE REGEX ".*(lib|dll|so)(\.[0-9]+)*$")
     list(REMOVE_DUPLICATES REQ_STANDALONE_LIBS)
 
     if(WIN32)


### PR DESCRIPTION
The newest ROS2 release comes with ddsc version update from 0.9.1 to 0.10.3. The current regex for validating standalone libraries can't handle multi-digital versions. This PR fixes it.

Same as https://github.com/RobotecAI/ros2cs/pull/57