### PR TITLE
Fix disabling ray distortion in raytrace

### DIFF
--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -261,7 +261,7 @@ typedef enum : int32_t
 	 * - linear velocity
 	 * - angular velocity
 	 * - mesh deformations (e.g. skinning)
-	 * The aforementioned are inferred from calls to `rgl_entity_set_pose`, `rgl_scene_set_time` and `rgL_mesh_update_vertices`.
+	 * The aforementioned are inferred from calls to `rgl_entity_set_pose`, `rgl_scene_set_time` and `rgl_mesh_update_vertices`.
 	 */
 	RGL_FIELD_ABSOLUTE_VELOCITY_VEC3_F32,
 
@@ -531,6 +531,7 @@ RGL_API rgl_status_t rgl_node_rays_transform(rgl_node_t* node, const rgl_mat3x4f
  */
 RGL_API rgl_status_t rgl_node_points_transform(rgl_node_t* node, const rgl_mat3x4f* transform);
 
+// TODO: remove scene parameter here and in other API calls
 /**
  * Creates or modifies RaytraceNode.
  * The Node performs GPU-accelerated raytracing on the given Scene.
@@ -542,6 +543,7 @@ RGL_API rgl_status_t rgl_node_points_transform(rgl_node_t* node, const rgl_mat3x
  */
 RGL_API rgl_status_t rgl_node_raytrace(rgl_node_t* node, rgl_scene_t scene);
 
+// TODO: Remove this API call on a new release. It is replaced by `rgl_node_raytrace_in_motion`.
 /**
  * Creates or modifies RaytraceNode.
  * The same as rgl_node_raytrace, but it applies velocity distortion additionally.
@@ -561,8 +563,31 @@ RGL_API rgl_status_t rgl_node_raytrace(rgl_node_t* node, rgl_scene_t scene);
 RGL_API rgl_status_t rgl_node_raytrace_with_distortion(rgl_node_t* node, rgl_scene_t scene, const rgl_vec3f* linear_velocity,
                                                        const rgl_vec3f* angular_velocity);
 
-// TODO: write doc once API call is accepted - this call is supposed to replace rgl_node_raytrace_with_distortion
-// TODO: remove scene parameter
+/**
+ * Creates or modifies RaytraceNode.
+ * The same as rgl_node_raytrace, but it provides sensor's velocity to the pipeline.
+ * It is required to perform velocity distortion or calculate fields: RGL_FIELD_RELATIVE_VELOCITY_VEC3_F32 and RGL_FIELD_RADIAL_SPEED_F32
+ *
+ * Velocity distortion:
+ * To perform raytrace with velocity distortion the time offsets must be set to the rays (using rgl_node_rays_set_time_offsets).
+ * The velocities passed to that node must be in the local coordinate frame in which rays are described.
+ * NOTE:
+ * The distortion takes into account only sensor velocity. The velocity of the objects being scanned by the sensor is not considered.
+ *
+ * Relative velocity calculation:
+ * To calculate relative velocity the pipeline must allow to compute absolute velocities. For more details refer to API calls documentation:
+ * `rgl_scene_set_time`, `rgl_entity_set_pose`, and `rgl_mesh_update_vertices`
+ *
+ * Graph input: rays
+ * Graph output: point cloud (sparse)
+ * @param node If (*node) == nullptr, a new node will be created. Otherwise, (*node) will be modified.
+ * @param scene Handle to a scene to perform raytracing on. Pass null to use the default scene
+ * @param linear_velocity Pointer to a single 3D vector describing the linear velocity of the sensor.
+ *                        The velocity is in units per second.
+ * @param angular_velocity Pointer to a single 3D vector describing the delta angular velocity of the sensor in euler angles (roll, pitch, yaw).
+ *                         The velocity is in radians per second.
+ * @param apply_ray_distortion If true, velocity distortion feature will be enabled.
+ */
 RGL_API rgl_status_t rgl_node_raytrace_in_motion(rgl_node_t* node, rgl_scene_t scene, const rgl_vec3f* linear_velocity,
                                                  const rgl_vec3f* angular_velocity, bool apply_ray_distortion);
 

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -804,8 +804,11 @@ RGL_API rgl_status_t rgl_node_raytrace(rgl_node_t* node, rgl_scene_t scene)
 		CHECK_ARG(scene == nullptr); // TODO: remove once rgl_scene_t param is removed
 
 		createOrUpdateNode<RaytraceNode>(node);
-		// Clear velocity that could be set by rgl_node_raytrace_with_distortion
-		Node::validatePtr<RaytraceNode>(*node)->setVelocity(Vec3f{0, 0, 0}, Vec3f{0, 0, 0});
+		auto raytraceNode = Node::validatePtr<RaytraceNode>(*node);
+		// Clear velocity that could be set by rgl_node_raytrace_in_motion
+		raytraceNode->setVelocity(Vec3f{0, 0, 0}, Vec3f{0, 0, 0});
+		// Disable ray distortion that could be set by rgl_node_raytrace_in_motion
+		raytraceNode->enableRayDistortion(false);
 	});
 	TAPE_HOOK(node, scene);
 	return status;

--- a/test/src/TapeTest.cpp
+++ b/test/src/TapeTest.cpp
@@ -105,6 +105,9 @@ TEST_F(TapeTest, RecordPlayAllCalls)
 	rgl_vec3f angularVelocity{1.0f, 2.0f, 3.0f};
 	EXPECT_RGL_SUCCESS(rgl_node_raytrace_with_distortion(&raytraceWithDistortion, nullptr, &linearVelocity, &angularVelocity));
 
+	rgl_node_t raytraceInMotion = nullptr;
+	EXPECT_RGL_SUCCESS(rgl_node_raytrace_in_motion(&raytraceInMotion, nullptr, &linearVelocity, &angularVelocity, false));
+
 	rgl_node_t format = nullptr;
 	std::vector<rgl_field_t> fields = {RGL_FIELD_XYZ_VEC3_F32, RGL_FIELD_DISTANCE_F32};
 	EXPECT_RGL_SUCCESS(rgl_node_points_format(&format, fields.data(), fields.size()));


### PR DESCRIPTION
PR contains:
- Fix for disabling ray distortion in `rgl_node_raytrace`
- Tape test for `rgl_node_raytrace_in_motion`
- Updated documentation for `rgl_node_raytrace_in_motion`