### PR TITLE
Add is_valid functions to entity, mesh and texture in public API

### DIFF
--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -460,6 +460,14 @@ RGL_API rgl_status_t rgl_mesh_destroy(rgl_mesh_t mesh);
  */
 RGL_API rgl_status_t rgl_mesh_update_vertices(rgl_mesh_t mesh, const rgl_vec3f* vertices, int32_t vertex_count);
 
+/**
+ * Assigns value true to out_valid if the given mesh is known and has not been destroyed,
+ * assigns value false otherwise.
+ * @param mesh Mesh to check for validity
+ * @param out_valid Boolean set to indicate validity
+ */
+RGL_API rgl_status_t rgl_is_mesh_valid(rgl_mesh_t mesh, bool* out_valid);
+
 /******************************** ENTITY ********************************/
 
 /**
@@ -496,9 +504,17 @@ RGL_API rgl_status_t rgl_entity_set_id(rgl_entity_t entity, int32_t id);
 /**
  * Assign intensity texture to the given Entity. The assumption is that the Entity can hold only one intensity texture.
  * @param entity Entity to modify.
- * @apram texture Texture to assign.
+ * @param texture Texture to assign.
  */
 RGL_API rgl_status_t rgl_entity_set_intensity_texture(rgl_entity_t entity, rgl_texture_t texture);
+
+/**
+ * Assigns value true to out_valid if the given entity is known and has not been destroyed,
+ * assigns value false otherwise.
+ * @param entity Entity to check for validity
+ * @param out_valid Boolean set to indicate validity
+ */
+RGL_API rgl_status_t rgl_is_entity_valid(rgl_entity_t entity, bool* out_valid);
 
 /******************************* TEXTURE *******************************/
 
@@ -515,9 +531,17 @@ RGL_API rgl_status_t rgl_texture_create(rgl_texture_t* out_texture, const void* 
 /**
  * Informs that the given texture will be no longer used.
  * The texture will be destroyed after all referring Entities are destroyed.
- * @param mesh Texture to be marked as no longer needed
+ * @param texture Texture to be marked as no longer needed
  */
 RGL_API rgl_status_t rgl_texture_destroy(rgl_texture_t texture);
+
+/**
+ * Assigns value true to out_valid if the given texture is known and has not been destroyed,
+ * assigns value false otherwise.
+ * @param texture Texture to check for validity
+ * @param out_valid Boolean set to indicate validity
+ */
+RGL_API rgl_status_t rgl_is_texture_valid(rgl_texture_t texture, bool* out_valid);
 
 /******************************** SCENE ********************************/
 

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -461,12 +461,12 @@ RGL_API rgl_status_t rgl_mesh_destroy(rgl_mesh_t mesh);
 RGL_API rgl_status_t rgl_mesh_update_vertices(rgl_mesh_t mesh, const rgl_vec3f* vertices, int32_t vertex_count);
 
 /**
- * Assigns value true to out_valid if the given mesh is known and has not been destroyed,
+ * Assigns value true to out_alive if the given mesh is known and has not been destroyed,
  * assigns value false otherwise.
- * @param mesh Mesh to check for validity
- * @param out_valid Boolean set to indicate validity
+ * @param mesh Mesh to check if alive
+ * @param out_alive Boolean set to indicate if alive
  */
-RGL_API rgl_status_t rgl_is_mesh_valid(rgl_mesh_t mesh, bool* out_valid);
+RGL_API rgl_status_t rgl_mesh_is_alive(rgl_mesh_t mesh, bool* out_alive);
 
 /******************************** ENTITY ********************************/
 
@@ -509,12 +509,12 @@ RGL_API rgl_status_t rgl_entity_set_id(rgl_entity_t entity, int32_t id);
 RGL_API rgl_status_t rgl_entity_set_intensity_texture(rgl_entity_t entity, rgl_texture_t texture);
 
 /**
- * Assigns value true to out_valid if the given entity is known and has not been destroyed,
+ * Assigns value true to out_alive if the given entity is known and has not been destroyed,
  * assigns value false otherwise.
- * @param entity Entity to check for validity
- * @param out_valid Boolean set to indicate validity
+ * @param entity Entity to check if alive
+ * @param out_alive Boolean set to indicate if alive
  */
-RGL_API rgl_status_t rgl_is_entity_valid(rgl_entity_t entity, bool* out_valid);
+RGL_API rgl_status_t rgl_entity_is_alive(rgl_entity_t entity, bool* out_alive);
 
 /******************************* TEXTURE *******************************/
 
@@ -536,12 +536,12 @@ RGL_API rgl_status_t rgl_texture_create(rgl_texture_t* out_texture, const void* 
 RGL_API rgl_status_t rgl_texture_destroy(rgl_texture_t texture);
 
 /**
- * Assigns value true to out_valid if the given texture is known and has not been destroyed,
+ * Assigns value true to out_alive if the given texture is known and has not been destroyed,
  * assigns value false otherwise.
- * @param texture Texture to check for validity
- * @param out_valid Boolean set to indicate validity
+ * @param texture Texture to check if alive
+ * @param out_alive Boolean set to indicate if alive
  */
-RGL_API rgl_status_t rgl_is_texture_valid(rgl_texture_t texture, bool* out_valid);
+RGL_API rgl_status_t rgl_texture_is_alive(rgl_texture_t texture, bool* out_alive);
 
 /******************************** SCENE ********************************/
 

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -855,6 +855,14 @@ RGL_API rgl_status_t rgl_node_gaussian_noise_angular_hitpoint(rgl_node_t* node, 
 RGL_API rgl_status_t rgl_node_gaussian_noise_distance(rgl_node_t* node, float mean, float st_dev_base,
                                                       float st_dev_rise_per_meter);
 
+/**
+ * Assigns value true to out_alive if the given node is known and has not been destroyed,
+ * assigns value false otherwise.
+ * @param node Node to check if alive
+ * @param out_alive Boolean set to indicate if alive
+ */
+RGL_API rgl_status_t rgl_node_is_alive(rgl_node_t node, bool* out_alive);
+
 /******************************** GRAPH ********************************/
 
 /**

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -256,13 +256,13 @@ void TapeCore::tape_mesh_update_vertices(const YAML::Node& yamlNode, PlaybackSta
 	                         yamlNode[2].as<int32_t>());
 }
 
-rgl_status_t rgl_is_mesh_valid(rgl_mesh_t mesh, bool* out_valid)
+rgl_status_t rgl_mesh_is_alive(rgl_mesh_t mesh, bool* out_alive)
 {
 	auto status = rglSafeCall([&]() {
-		CHECK_ARG(out_valid != nullptr);
-		*out_valid = Mesh::instances.contains(mesh);
+		CHECK_ARG(out_alive != nullptr);
+		*out_alive = Mesh::instances.contains(mesh);
 	});
-	TAPE_HOOK(mesh, out_valid);
+	TAPE_HOOK(mesh, out_alive);
 	return status;
 }
 
@@ -365,12 +365,13 @@ void TapeCore::tape_entity_set_intensity_texture(const YAML::Node& yamlNode, Pla
 	                                 state.textures.at(yamlNode[1].as<TapeAPIObjectID>()));
 }
 
-rgl_status_t rgl_is_entity_valid(rgl_entity_t entity, bool* out_valid)
+rgl_status_t rgl_entity_is_alive(rgl_entity_t entity, bool* out_alive)
 {
 	auto status = rglSafeCall([&]() {
-		*out_valid = Entity::instances.find(entity) != Entity::instances.end();
+		CHECK_ARG(out_alive != nullptr);
+		*out_alive = Entity::instances.contains(entity);
 	});
-	TAPE_HOOK();
+	TAPE_HOOK(entity, out_alive);
 	return status;
 }
 
@@ -417,12 +418,13 @@ void TapeCore::tape_texture_destroy(const YAML::Node& yamlNode, PlaybackState& s
 	state.textures.erase(textureId);
 }
 
-rgl_status_t rgl_is_texture_valid(rgl_texture_t texture, bool* out_valid)
+rgl_status_t rgl_texture_is_alive(rgl_texture_t texture, bool* out_alive)
 {
 	auto status = rglSafeCall([&]() {
-		*out_valid = Texture::instances.find(texture) != Texture::instances.end();
+		CHECK_ARG(out_alive != nullptr);
+		*out_alive = Texture::instances.contains(texture);
 	});
-	TAPE_HOOK();
+	TAPE_HOOK(texture, out_alive);
 	return status;
 }
 

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -259,9 +259,10 @@ void TapeCore::tape_mesh_update_vertices(const YAML::Node& yamlNode, PlaybackSta
 rgl_status_t rgl_is_mesh_valid(rgl_mesh_t mesh, bool* out_valid)
 {
 	auto status = rglSafeCall([&]() {
-		*out_valid = Mesh::instances.find(mesh) != Mesh::instances.end();
+		CHECK_ARG(out_valid != nullptr);
+		*out_valid = Mesh::instances.contains(mesh);
 	});
-	TAPE_HOOK();
+	TAPE_HOOK(mesh, out_valid);
 	return status;
 }
 

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -256,6 +256,15 @@ void TapeCore::tape_mesh_update_vertices(const YAML::Node& yamlNode, PlaybackSta
 	                         yamlNode[2].as<int32_t>());
 }
 
+rgl_status_t rgl_is_mesh_valid(rgl_mesh_t mesh, bool* out_valid)
+{
+	auto status = rglSafeCall([&]() {
+		*out_valid = Mesh::instances.find(mesh) != Mesh::instances.end();
+	});
+	TAPE_HOOK();
+	return status;
+}
+
 RGL_API rgl_status_t rgl_entity_create(rgl_entity_t* out_entity, rgl_scene_t scene, rgl_mesh_t mesh)
 {
 	auto status = rglSafeCall([&]() {
@@ -355,6 +364,15 @@ void TapeCore::tape_entity_set_intensity_texture(const YAML::Node& yamlNode, Pla
 	                                 state.textures.at(yamlNode[1].as<TapeAPIObjectID>()));
 }
 
+rgl_status_t rgl_is_entity_valid(rgl_entity_t entity, bool* out_valid)
+{
+	auto status = rglSafeCall([&]() {
+		*out_valid = Entity::instances.find(entity) != Entity::instances.end();
+	});
+	TAPE_HOOK();
+	return status;
+}
+
 RGL_API rgl_status_t rgl_texture_create(rgl_texture_t* out_texture, const void* texels, int32_t width, int32_t height)
 {
 	auto status = rglSafeCall([&]() {
@@ -396,6 +414,15 @@ void TapeCore::tape_texture_destroy(const YAML::Node& yamlNode, PlaybackState& s
 	auto textureId = yamlNode[0].as<TapeAPIObjectID>();
 	rgl_texture_destroy(state.textures.at(textureId));
 	state.textures.erase(textureId);
+}
+
+rgl_status_t rgl_is_texture_valid(rgl_texture_t texture, bool* out_valid)
+{
+	auto status = rglSafeCall([&]() {
+		*out_valid = Texture::instances.find(texture) != Texture::instances.end();
+	});
+	TAPE_HOOK();
+	return status;
 }
 
 RGL_API rgl_status_t rgl_scene_set_time(rgl_scene_t scene, uint64_t nanoseconds)

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1219,6 +1219,16 @@ void TapeCore::tape_node_gaussian_noise_distance(const YAML::Node& yamlNode, Pla
 	state.nodes.insert({nodeId, node});
 }
 
+rgl_status_t rgl_node_is_alive(rgl_node_t node, bool* out_alive)
+{
+	auto status = rglSafeCall([&]() {
+		CHECK_ARG(out_alive != nullptr);
+		*out_alive = Node::instances.contains(node);
+	});
+	TAPE_HOOK(node, out_alive);
+	return status;
+}
+
 RGL_API rgl_status_t rgl_tape_record_begin(const char* path)
 {
 /**


### PR DESCRIPTION
This is really useful for example where some application or library has reference-counted wrappers of rgl-entities, rgl-meshes or rgl-textures which calls rgl_xxx_destroy once the last referenced object is destroyed. If some lingering reference exists (for example in client code) after e.g. rgl_cleanup() has been called called, an error is produced since then, rgl_xxx_destroy is called after rgl_cleanup. 

So by adding these functions, the application or library can check if the entity/mesh/texture is still valid, and only if it is, call rgl_xxx_destroy. For example. There probably exists other use cases as well.