### PR TITLE
Set default debug postfix if not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,19 @@
 cmake_minimum_required(VERSION 3.18)  # 3.18 To automatically detect CUDA_ARCHITECTURES
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CUDA_STANDARD 17)
+
 # Build Release by default; CMAKE_BUILD_TYPE needs to be set before project(...)
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING
         "Choose the type of build, options are: Debug Release RelWithDebInfo MinSizeRel" FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
+
+# Use debug postfix 'd' by default.
+if(NOT CMAKE_DEBUG_POSTFIX)
+  set(CMAKE_DEBUG_POSTFIX "d" CACHE STRING
+      "Choose the debug postfix used when building Debug configuration")
+endif()
+
 project(RobotecGPULidar C CXX CUDA)
 
 # Logging default settings (can be changed via API call)


### PR DESCRIPTION
This is mostly a suggestion. 
This change makes it possible to have release and debug binaries without name collision out of the box.
So, when building Release followed by Debug, the binary files does not overwrite each other in the Build directory.
Having debug postfix 'd' is somewhat standard.

If for example, a multi-configuration IDE as Visual Studio is used to build an application depending on rgl, it is convenient being able to point out debug and release binaries with unique names to ensure the correct (dll) is loaded.  