### PR TITLE
feature/static-build: Static link library build and linkage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ cmake-build-debug
 cmake-build-release
 build
 external/vcpkg
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ set(RGL_LOG_FILE "" CACHE STRING  # STRING prevents from expanding relative path
 set(RGL_AUTO_TAPE_PATH "" CACHE STRING  # STRING prevents from expanding relative paths
     "If non-empty, defines a path for the automatic tape (started on the first API call)")
 
+# Library configuration
+set(RGL_BUILD_STATIC OFF CACHE BOOL
+    "Builds RobotecGPULidar as a statically linkable library instead of a shared one")
+
 # Test configuration
 set(RGL_BUILD_TESTS ON CACHE BOOL
     "Enables building test. GTest will be automatically downloaded")
@@ -76,7 +80,7 @@ add_custom_command(
     VERBATIM)
 add_library(optixPrograms optixProgramsPtx.c)
 
-add_library(RobotecGPULidar SHARED
+set(RobotecGPULidarSources
     src/api/apiCommon.cpp
     src/api/apiCore.cpp
     src/Tape.cpp
@@ -109,6 +113,13 @@ add_library(RobotecGPULidar SHARED
     src/graph/TemporalMergePointsNode.cpp
     src/graph/YieldPointsNode.cpp
 )
+
+if (RGL_BUILD_STATIC)
+    add_library(RobotecGPULidar STATIC ${RobotecGPULidarSources})
+    target_compile_definitions(RobotecGPULidar PUBLIC RGL_STATIC_BUILD)
+else ()
+    add_library(RobotecGPULidar SHARED ${RobotecGPULidarSources})
+endif ()
 
 set_property(TARGET RobotecGPULidar PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ target_include_directories(RobotecGPULidar
 )
 
 target_link_libraries(RobotecGPULidar PRIVATE
-    spdlog
+    spdlog_header_only
     yaml-cpp
     optixPrograms
     cmake_git_version_tracking

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,8 +117,10 @@ set(RGL_SOURCE_FILES
 if (RGL_BUILD_STATIC)
     add_library(RobotecGPULidar STATIC ${RGL_SOURCE_FILES})
     target_compile_definitions(RobotecGPULidar PUBLIC RGL_STATIC)
+    set(RGL_SPDLOG_VARIANT spdlog_header_only)
 else ()
     add_library(RobotecGPULidar SHARED ${RGL_SOURCE_FILES})
+    set(RGL_SPDLOG_VARIANT spdlog)
 endif ()
 
 set_property(TARGET RobotecGPULidar PROPERTY POSITION_INDEPENDENT_CODE ON)
@@ -145,7 +147,7 @@ target_include_directories(RobotecGPULidar
 )
 
 target_link_libraries(RobotecGPULidar PRIVATE
-    spdlog_header_only
+    ${RGL_SPDLOG_VARIANT}
     yaml-cpp
     optixPrograms
     cmake_git_version_tracking

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ set(RGL_SOURCE_FILES
 
 if (RGL_BUILD_STATIC)
     add_library(RobotecGPULidar STATIC ${RGL_SOURCE_FILES})
-    target_compile_definitions(RobotecGPULidar PUBLIC RGL_STATIC_BUILD)
+    target_compile_definitions(RobotecGPULidar PUBLIC RGL_STATIC)
 else ()
     add_library(RobotecGPULidar SHARED ${RGL_SOURCE_FILES})
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ add_custom_command(
     VERBATIM)
 add_library(optixPrograms optixProgramsPtx.c)
 
-set(RobotecGPULidarSources
+set(RGL_SOURCE_FILES
     src/api/apiCommon.cpp
     src/api/apiCore.cpp
     src/Tape.cpp
@@ -115,10 +115,10 @@ set(RobotecGPULidarSources
 )
 
 if (RGL_BUILD_STATIC)
-    add_library(RobotecGPULidar STATIC ${RobotecGPULidarSources})
+    add_library(RobotecGPULidar STATIC ${RGL_SOURCE_FILES})
     target_compile_definitions(RobotecGPULidar PUBLIC RGL_STATIC_BUILD)
 else ()
-    add_library(RobotecGPULidar SHARED ${RobotecGPULidarSources})
+    add_library(RobotecGPULidar SHARED ${RGL_SOURCE_FILES})
 endif ()
 
 set_property(TARGET RobotecGPULidar PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -24,6 +24,9 @@
 #define NO_MANGLING
 #endif
 
+#if defined RGL_STATIC
+#define RGL_VISIBLE
+#else
 #if defined _WIN32 || defined __CYGWIN__
 #ifdef __GNUC__
 #define RGL_VISIBLE __attribute__((dllexport))
@@ -38,6 +41,7 @@
 #define RGL_VISIBLE
 #endif
 #endif // _WIN32 || __CYGWIN__
+#endif // RGL_STATIC
 
 #define RGL_API NO_MANGLING RGL_VISIBLE
 


### PR DESCRIPTION
# `feature/static-build`: Static link library build and linkage

Added building of static library version of RGL without compromising the shared library version.

## Changes:

* Added option `RGL_BUILD_STATIC`, defaulting to `OFF`, to main folder `CMakeLists.txt`. When `ON`, `RGL_BUILD_STATIC` defines `RGL_STATIC`.
* Resolved issues related to linking of static link library version of RGL by switching to `header-only`-version of `spdlog`, ie. `spdlog_header_only`, when `RGL_BUILD_STATIC` is `ON`.
* Disabled dynamic library export attributes if `RGL_STATIC` is defined.

## Ensured building, linking and tests executing for:

* Windows 11 (10.0.22621), MSVC 19.29.30153.0, CUDA Toolkit 11.4 v11.4.152, NVIDIA OptiX 7.2:
	- Shared library, x64 Debug configuration
	- Static library, x64 Debug configuration
	- Shared library, x64 Release configuration (no DebInfo)
	- Static library, x64 Release configuration (no DebInfo)
* Ubuntu 22.04, GNU 11.4.0, CUDA Toolkit 12.4 v12.4.99, NVIDIA OptiX 7.2:
	- Shared library, x64 Debug configuration
	- Static library, x64 Debug configuration
	- Shared library, x64 Release configuration
	- Static library, x64 Release configuration