### PR TITLE
Fix windows build error due to windows header definition leakage

### DIFF
--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -644,14 +644,14 @@ RGL_API rgl_status_t rgl_node_raytrace_configure_distortion(rgl_node_t node, boo
  * Modifies RaytraceNode to set non-hit values for distance.
  * Default non-hit value for the RGL_FIELD_DISTANCE_F32 field is set to infinity.
  * This function allows to set custom values:
- *  - for non-hits closer than a minimum range (`near`),
- *  - for non-hits beyond a maximum range (`far`).
+ *  - for non-hits closer than a minimum range (`nearDistance`),
+ *  - for non-hits beyond a maximum range (`farDistance`).
  * Concurrently, it computes the RGL_FIELD_XYZ_VEC3_F32 field for these non-hit scenarios based on these distances, along with ray origin and direction.
  * @param node RaytraceNode to modify.
- * @param near Distance value for non-hits closer than minimum range.
- * @param far Distance value for non-hits beyond maximum range.
+ * @param nearDistance Distance value for non-hits closer than minimum range.
+ * @param farDistance Distance value for non-hits beyond maximum range.
  */
-RGL_API rgl_status_t rgl_node_raytrace_configure_non_hits(rgl_node_t node, float near, float far);
+RGL_API rgl_status_t rgl_node_raytrace_configure_non_hits(rgl_node_t node, float nearDistance, float farDistance);
 
 /**
  * Creates or modifies FormatPointsNode.

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -28,6 +28,18 @@
 #include <graph/GraphRunCtx.hpp>
 #include <NvtxWrappers.hpp>
 
+#ifdef _WIN32
+// near defined in minwindef.h causing compile error on Windows.
+#if defined(near)
+#undef near
+#endif
+
+// far defined in minwindef.h causing compile error on Windows.
+#if defined(far)
+#undef far
+#endif
+#endif // _WIN32
+
 extern "C" {
 
 RGL_API rgl_status_t rgl_get_version_info(int32_t* out_major, int32_t* out_minor, int32_t* out_patch)

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -28,18 +28,6 @@
 #include <graph/GraphRunCtx.hpp>
 #include <NvtxWrappers.hpp>
 
-#ifdef _WIN32
-// near defined in minwindef.h causing compile error on Windows.
-#if defined(near)
-#undef near
-#endif
-
-// far defined in minwindef.h causing compile error on Windows.
-#if defined(far)
-#undef far
-#endif
-#endif // _WIN32
-
 extern "C" {
 
 RGL_API rgl_status_t rgl_get_version_info(int32_t* out_major, int32_t* out_minor, int32_t* out_patch)
@@ -881,15 +869,17 @@ void TapeCore::tape_node_raytrace_configure_distortion(const YAML::Node& yamlNod
 	rgl_node_raytrace_configure_distortion(node, yamlNode[1].as<bool>());
 }
 
-RGL_API rgl_status_t rgl_node_raytrace_configure_non_hits(rgl_node_t node, float near, float far)
+RGL_API rgl_status_t rgl_node_raytrace_configure_non_hits(rgl_node_t node, float nearDistance,
+	float farDistance)
 {
 	auto status = rglSafeCall([&]() {
-		RGL_API_LOG("rgl_node_raytrace_configure_non_hits(node={}, near={}, far={})", repr(node), near, far);
+		RGL_API_LOG("rgl_node_raytrace_configure_non_hits(node={}, nearDistance={}, farDistance={})",
+			repr(node), nearDistance, farDistance);
 		CHECK_ARG(node != nullptr);
 		RaytraceNode::Ptr raytraceNode = Node::validatePtr<RaytraceNode>(node);
-		raytraceNode->setNonHitDistanceValues(near, far);
+		raytraceNode->setNonHitDistanceValues(nearDistance, farDistance);
 	});
-	TAPE_HOOK(node, near, far);
+	TAPE_HOOK(node, nearDistance, farDistance);
 	return status;
 }
 

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -125,7 +125,7 @@ struct RaytraceNode : IPointsNode
 	// RaytraceNode specific
 	void setVelocity(const Vec3f& linearVelocity, const Vec3f& angularVelocity);
 	void enableRayDistortion(bool enabled) { doApplyDistortion = enabled; }
-	void setNonHitDistanceValues(float near, float far);
+	void setNonHitDistanceValues(float nearDistance, float farDistance);
 
 private:
 	IRaysNode::Ptr raysNode;

--- a/src/graph/RaytraceNode.cpp
+++ b/src/graph/RaytraceNode.cpp
@@ -20,6 +20,18 @@
 #include <macros/optix.hpp>
 #include <RGLFields.hpp>
 
+#ifdef _WIN32
+// near defined in minwindef.h causing compile error on Windows.
+#if defined(near)
+#undef near
+#endif
+
+// far defined in minwindef.h causing compile error on Windows.
+#if defined(far)
+#undef far
+#endif
+#endif // _WIN32
+
 void RaytraceNode::setParameters()
 {
 	const static Vec2f defaultRangeValue = Vec2f(0.0f, FLT_MAX);

--- a/src/graph/RaytraceNode.cpp
+++ b/src/graph/RaytraceNode.cpp
@@ -20,18 +20,6 @@
 #include <macros/optix.hpp>
 #include <RGLFields.hpp>
 
-#ifdef _WIN32
-// near defined in minwindef.h causing compile error on Windows.
-#if defined(near)
-#undef near
-#endif
-
-// far defined in minwindef.h causing compile error on Windows.
-#if defined(far)
-#undef far
-#endif
-#endif // _WIN32
-
 void RaytraceNode::setParameters()
 {
 	const static Vec2f defaultRangeValue = Vec2f(0.0f, FLT_MAX);
@@ -184,8 +172,8 @@ void RaytraceNode::setVelocity(const Vec3f& linearVelocity, const Vec3f& angular
 	sensorAngularVelocityRPY = angularVelocity;
 }
 
-void RaytraceNode::setNonHitDistanceValues(float near, float far)
+void RaytraceNode::setNonHitDistanceValues(float nearDistance, float farDistance)
 {
-	nearNonHitDistance = near;
-	farNonHitDistance = far;
+	nearNonHitDistance = nearDistance;
+	farNonHitDistance = farDistance;
 }


### PR DESCRIPTION
A few functions in the develop branch uses parameters "near" and "far".
On Windows, these are defined in minwindef.h which causes build error(s).

This PR fixes this build error by undefining these keywords if they are defined (Windows only).