### PR TITLE
Add node for radar object tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,7 @@ add_library(RobotecGPULidar SHARED
     src/graph/FromMat3x4fRaysNode.cpp
     src/graph/FilterGroundPointsNode.cpp
     src/graph/RadarPostprocessPointsNode.cpp
+    src/graph/RadarTrackObjectsNode.cpp
     src/graph/SetRangeRaysNode.cpp
     src/graph/SetRaysRingIdsRaysNode.cpp
     src/graph/SetTimeOffsetsRaysNode.cpp

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -831,16 +831,16 @@ RGL_API rgl_status_t rgl_node_points_radar_postprocess(rgl_node_t* node, const r
 /**
  * Creates or modifies RadarTrackObjectsNode.
  * The Node takes radar detections point cloud as input (from rgl_node_points_radar_postprocess), groups detections into objects based on given thresholds (node parameters),
- * and calculates various characteristics of these objects. This Node is intended to be connected to object list publishing node (from rgl_node_publish_udp_objectlist). The
- * output from this Node is in the form of a point cloud, where point XYZ coordinates are tracked objects positions.
+ * and calculates various characteristics of these objects. This Node is intended to be connected to object list publishing node (from rgl_node_publish_udp_objectlist).
+ * The output from this Node is in the form of a point cloud, where point XYZ coordinates are tracked objects positions.
  * Note that for correct calculation and publishing some of object characteristics (e.g. velocity) user has to call rgl_scene_set_time for current scene.
  * Graph input: point cloud, containing RGL_FIELD_DISTANCE_F32, RGL_FIELD_AZIMUTH_F32, RGL_FIELD_ELEVATION_F32 and RGL_FIELD_RADIAL_SPEED_F32
  * Graph output: point cloud
  * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.
- * @param object_distance_threshold The maximum distance between any radar detection and other detection closest to it within the same tracked object (in meters).
- * @param object_azimuth_threshold The maximum azimuth difference between any radar detection and other detection closest to it within the same tracked object (in radians).
- * @param object_elevation_threshold The maximum elevation difference between any radar detection and other detection closest to it within the same tracked object (in radians).
- * @param object_radial_speed_threshold The maximum radial speed difference between any radar detection and other detection closest to it within the same tracked object (in meters per second).
+ * @param object_distance_threshold The maximum distance between a radar detection and other closest detection classified as the same tracked object (in meters).
+ * @param object_azimuth_threshold The maximum azimuth difference between a radar detection and other closest detection classified as the same tracked object (in radians).
+ * @param object_elevation_threshold The maximum elevation difference between a radar detection and other closest detection classified as the same tracked object (in radians).
+ * @param object_radial_speed_threshold The maximum radial speed difference between a radar detection and other closest detection classified as the same tracked object (in meters per second).
  */
 RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node, float object_distance_threshold,
                                                          float object_azimuth_threshold, float object_elevation_threshold,

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -782,6 +782,12 @@ RGL_API rgl_status_t rgl_node_points_radar_postprocess(rgl_node_t* node, const r
                                                        float received_noise_st_dev);
 
 /**
+ * Create or modify RadarTrackObjectsNode.
+ * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.
+ */
+RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node);
+
+/**
  * Creates or modifies FilterGroundPointsNode.
  * The Node adds RGL_FIELD_IS_GROUND_I32 which indicates the point is on the ground. Points are not removed.
  * Ground points are defined as those located below the sensor with a normal vector pointing upwards at an angle smaller than the threshold.

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -829,10 +829,22 @@ RGL_API rgl_status_t rgl_node_points_radar_postprocess(rgl_node_t* node, const r
                                                        float received_noise_st_dev);
 
 /**
- * Create or modify RadarTrackObjectsNode.
+ * Creates or modifies RadarTrackObjectsNode.
+ * The Node takes radar detections point cloud as input (from rgl_node_points_radar_postprocess), groups detections into objects based on given thresholds (node parameters),
+ * and calculates various characteristics of these objects. This Node is intended to be connected to object list publishing node (from rgl_node_publish_udp_objectlist). The
+ * output from this Node is in the form of a point cloud, where point XYZ coordinates are tracked objects positions.
+ * Note that for correct calculation and publishing some of object characteristics (e.g. velocity) user has to call rgl_scene_set_time for current scene.
+ * Graph input: point cloud, containing RGL_FIELD_DISTANCE_F32, RGL_FIELD_AZIMUTH_F32, RGL_FIELD_ELEVATION_F32 and RGL_FIELD_RADIAL_SPEED_F32
+ * Graph output: point cloud
  * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.
+ * @param object_distance_threshold The maximum distance between any radar detection and other detection closest to it within the same tracked object.
+ * @param object_azimuth_threshold The maximum azimuth difference between any radar detection and other detection closest to it within the same tracked object.
+ * @param object_elevation_threshold The maximum elevation difference between any radar detection and other detection closest to it within the same tracked object.
+ * @param object_radial_speed_threshold The maximum radial speed difference between any radar detection and other detection closest to it within the same tracked object.
  */
-RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node);
+RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node, float object_distance_threshold,
+                                                         float object_azimuth_threshold, float object_elevation_threshold,
+                                                         float object_radial_speed_threshold);
 
 /**
  * Creates or modifies FilterGroundPointsNode.

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -837,10 +837,10 @@ RGL_API rgl_status_t rgl_node_points_radar_postprocess(rgl_node_t* node, const r
  * Graph input: point cloud, containing RGL_FIELD_DISTANCE_F32, RGL_FIELD_AZIMUTH_F32, RGL_FIELD_ELEVATION_F32 and RGL_FIELD_RADIAL_SPEED_F32
  * Graph output: point cloud
  * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.
- * @param object_distance_threshold The maximum distance between any radar detection and other detection closest to it within the same tracked object.
- * @param object_azimuth_threshold The maximum azimuth difference between any radar detection and other detection closest to it within the same tracked object.
- * @param object_elevation_threshold The maximum elevation difference between any radar detection and other detection closest to it within the same tracked object.
- * @param object_radial_speed_threshold The maximum radial speed difference between any radar detection and other detection closest to it within the same tracked object.
+ * @param object_distance_threshold The maximum distance between any radar detection and other detection closest to it within the same tracked object (in meters).
+ * @param object_azimuth_threshold The maximum azimuth difference between any radar detection and other detection closest to it within the same tracked object (in radians).
+ * @param object_elevation_threshold The maximum elevation difference between any radar detection and other detection closest to it within the same tracked object (in radians).
+ * @param object_radial_speed_threshold The maximum radial speed difference between any radar detection and other detection closest to it within the same tracked object (in meters per second).
  */
 RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node, float object_distance_threshold,
                                                          float object_azimuth_threshold, float object_elevation_threshold,

--- a/src/Time.hpp
+++ b/src/Time.hpp
@@ -31,6 +31,7 @@ struct Time
 	static Time nanoseconds(uint64_t nanoseconds) { return Time(nanoseconds); }
 
 	HostDevFn double asSeconds() const { return static_cast<double>(timeNs) * 1.0e-9; };
+	HostDevFn double asMilliseconds() const { return static_cast<double>(timeNs) * 1.0e-6; };
 	HostDevFn uint64_t asNanoseconds() const { return timeNs; }
 
 #if RGL_BUILD_ROS2_EXTENSION

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1101,6 +1101,26 @@ void TapeCore::tape_node_points_radar_postprocess(const YAML::Node& yamlNode, Pl
 	state.nodes.insert({nodeId, node});
 }
 
+RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node)
+{
+	auto status = rglSafeCall([&]() {
+		RGL_API_LOG("rgl_node_points_radar_track_objects(node={})", repr(node));
+		CHECK_ARG(node != nullptr);
+
+		createOrUpdateNode<RadarTrackObjectsNode>(node);
+	});
+	TAPE_HOOK(node);
+	return status;
+}
+
+void TapeCore::tape_node_points_radar_track_objects(const YAML::Node& yamlNode, PlaybackState& state)
+{
+	auto nodeId = yamlNode[0].as<TapeAPIObjectID>();
+	rgl_node_t node = state.nodes.contains(nodeId) ? state.nodes.at(nodeId) : nullptr;
+	rgl_node_points_radar_track_objects(&node);
+	state.nodes.insert({nodeId, node});
+}
+
 RGL_API rgl_status_t rgl_node_points_filter_ground(rgl_node_t* node, const rgl_vec3f* sensor_up_vector,
                                                    float ground_angle_threshold)
 {

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1131,15 +1131,26 @@ void TapeCore::tape_node_points_radar_postprocess(const YAML::Node& yamlNode, Pl
 	state.nodes.insert({nodeId, node});
 }
 
-RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node)
+RGL_API rgl_status_t rgl_node_points_radar_track_objects(rgl_node_t* node, float object_distance_threshold,
+                                                         float object_azimuth_threshold, float object_elevation_threshold,
+                                                         float object_radial_speed_threshold)
 {
 	auto status = rglSafeCall([&]() {
-		RGL_API_LOG("rgl_node_points_radar_track_objects(node={})", repr(node));
+		RGL_API_LOG("rgl_node_points_radar_track_objects(node={}, object_distance_threshold={}, object_azimuth_threshold={}, "
+		            "object_elevation_threshold={}, object_radial_speed_threshold={})",
+		            repr(node), object_distance_threshold, object_azimuth_threshold, object_elevation_threshold,
+		            object_radial_speed_threshold);
 		CHECK_ARG(node != nullptr);
+		CHECK_ARG(object_distance_threshold > 0.0f);
+		CHECK_ARG(object_azimuth_threshold > 0.0f);
+		CHECK_ARG(object_elevation_threshold > 0.0f);
+		CHECK_ARG(object_radial_speed_threshold > 0.0f);
 
-		createOrUpdateNode<RadarTrackObjectsNode>(node);
+		createOrUpdateNode<RadarTrackObjectsNode>(node, object_distance_threshold, object_azimuth_threshold,
+		                                          object_elevation_threshold, object_radial_speed_threshold);
 	});
-	TAPE_HOOK(node);
+	TAPE_HOOK(node, object_distance_threshold, object_azimuth_threshold, object_elevation_threshold,
+	          object_radial_speed_threshold);
 	return status;
 }
 
@@ -1147,7 +1158,8 @@ void TapeCore::tape_node_points_radar_track_objects(const YAML::Node& yamlNode, 
 {
 	auto nodeId = yamlNode[0].as<TapeAPIObjectID>();
 	rgl_node_t node = state.nodes.contains(nodeId) ? state.nodes.at(nodeId) : nullptr;
-	rgl_node_points_radar_track_objects(&node);
+	rgl_node_points_radar_track_objects(&node, yamlNode[1].as<float>(), yamlNode[2].as<float>(), yamlNode[3].as<float>(),
+	                                    yamlNode[4].as<float>());
 	state.nodes.insert({nodeId, node});
 }
 

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -642,7 +642,8 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 
 	RadarTrackObjectsNode();
 
-	void setParameters();
+	void setParameters(float distanceThreshold, float azimuthThreshold, float elevationThreshold,
+	                   float radialSpeedThreshold);
 
 	// Node
 	void validateImpl() override;
@@ -663,6 +664,11 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 private:
 	std::list<ObjectState> objectStates;
 	std::unordered_map<rgl_field_t, IAnyArray::Ptr> fieldData;
+
+	float distanceThreshold;
+	float azimuthThreshold;
+	float elevationThreshold;
+	float radialSpeedThreshold;
 
 	HostPinnedArray<Field<XYZ_VEC3_F32>::type>::Ptr xyzHostPtr = HostPinnedArray<Field<XYZ_VEC3_F32>::type>::create();
 	HostPinnedArray<Field<DISTANCE_F32>::type>::Ptr distanceHostPtr = HostPinnedArray<Field<DISTANCE_F32>::type>::create();

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -564,25 +564,34 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 		uint32_t id;
 	};
 
+	RadarTrackObjectsNode();
+
 	void setParameters();
 
 	// Node
 	void validateImpl() override;
 	void enqueueExecImpl() override;
 
+	bool hasField(rgl_field_t field) const override { return fieldData.contains(field); }
+
 	// Node requirements
 	std::vector<rgl_field_t> getRequiredFieldList() const override;
 
 	// Data getters
-	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override;
+	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override { return fieldData.at(field); }
 
-	const std::list<ObjectState>& getObjectStates() const
-	{
-		return objectStates;
-	}
+	const std::list<ObjectState>& getObjectStates() const { return objectStates; }
 
 private:
 	std::list<ObjectState> objectStates;
+	std::unordered_map<rgl_field_t, IAnyArray::Ptr> fieldData;
+
+	HostPinnedArray<Field<XYZ_VEC3_F32>::type>::Ptr xyzHostPtr = HostPinnedArray<Field<XYZ_VEC3_F32>::type>::create();
+	HostPinnedArray<Field<DISTANCE_F32>::type>::Ptr distanceHostPtr = HostPinnedArray<Field<DISTANCE_F32>::type>::create();
+	HostPinnedArray<Field<AZIMUTH_F32>::type>::Ptr azimuthHostPtr = HostPinnedArray<Field<AZIMUTH_F32>::type>::create();
+	HostPinnedArray<Field<ELEVATION_F32>::type>::Ptr elevationHostPtr = HostPinnedArray<Field<ELEVATION_F32>::type>::create();
+	HostPinnedArray<Field<RADIAL_SPEED_F32>::type>::Ptr radialSpeedHostPtr =
+	    HostPinnedArray<Field<RADIAL_SPEED_F32>::type>::create();
 };
 
 struct FilterGroundPointsNode : IPointsNodeSingleInput

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -30,6 +30,7 @@
 #include <gpu/nodeKernels.hpp>
 #include <CacheManager.hpp>
 #include <GPUFieldDescBuilder.hpp>
+#include <math/RuningStats.hpp>
 
 
 struct FormatPointsNode : IPointsNodeSingleInput
@@ -559,9 +560,51 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 {
 	using Ptr = std::shared_ptr<RadarTrackObjectsNode>;
 
+	enum class ObjectStatus : uint8_t
+	{
+		Measured = 0,
+		New = 1,
+		Predicted = 2,
+		Invalid = 255
+	};
+
+	enum class MovementStatus : uint8_t
+	{
+		Moved = 0,
+		Stationary = 1,
+		Invalid = 255
+	};
+
+	struct Probabilities
+	{
+		float existence{100.0f};
+		uint8_t classCar{0};
+		uint8_t classTruck{0};
+		uint8_t classMotorcycle{0};
+		uint8_t classBicycle{0};
+		uint8_t classPedestrian{0};
+		uint8_t classAnimal{0};
+		uint8_t classHazard{0};
+	};
+
 	struct ObjectState
 	{
-		uint32_t id;
+		uint32_t id{0};
+		uint32_t framesCount{0};
+		uint32_t creationTime{0};
+		ObjectStatus objectStatus{ObjectStatus::Invalid};
+		MovementStatus movementStatus{MovementStatus::Invalid};
+		Probabilities probabilities{};
+
+		RunningStats<Vec3f> position{};
+		RunningStats<float> orientation{};
+		RunningStats<Vec2f> absVelocity{};
+		RunningStats<Vec2f> relVelocity{};
+		RunningStats<Vec2f> absAccel{};
+		RunningStats<Vec2f> relAccel{};
+		RunningStats<float> orientationRate{};
+		RunningStats<float> length{};
+		RunningStats<float> width{};
 	};
 
 	RadarTrackObjectsNode();

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -608,7 +608,7 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 		Invalid = 255
 	};
 
-	struct Probabilities
+	struct ClassificationProbabilities
 	{
 		float existence{100.0f};
 		uint8_t classCar{0};
@@ -627,7 +627,7 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 		uint32_t creationTime{0};
 		ObjectStatus objectStatus{ObjectStatus::Invalid};
 		MovementStatus movementStatus{MovementStatus::Invalid};
-		Probabilities probabilities{};
+		ClassificationProbabilities classificationProbabilities{};
 
 		RunningStats<Vec3f> position{};
 		RunningStats<float> orientation{};

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -555,6 +555,36 @@ private:
 	};
 };
 
+struct RadarTrackObjectsNode : IPointsNodeSingleInput
+{
+	using Ptr = std::shared_ptr<RadarTrackObjectsNode>;
+
+	struct ObjectState
+	{
+		uint32_t id;
+	};
+
+	void setParameters();
+
+	// Node
+	void validateImpl() override;
+	void enqueueExecImpl() override;
+
+	// Node requirements
+	std::vector<rgl_field_t> getRequiredFieldList() const override { return { /* define later */ }; };
+
+	// Data getters
+	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override;
+
+	const std::list<ObjectState>& getObjectStates() const
+	{
+		return objectStates;
+	}
+
+private:
+	std::list<ObjectState> objectStates;
+};
+
 struct FilterGroundPointsNode : IPointsNodeSingleInput
 {
 	using Ptr = std::shared_ptr<FilterGroundPointsNode>;

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -571,7 +571,7 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 	void enqueueExecImpl() override;
 
 	// Node requirements
-	std::vector<rgl_field_t> getRequiredFieldList() const override { return { /* define later */ }; };
+	std::vector<rgl_field_t> getRequiredFieldList() const override;
 
 	// Data getters
 	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override;

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -579,6 +579,8 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 
 	// Data getters
 	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override { return fieldData.at(field); }
+	size_t getWidth() const override { return fieldData.empty() ? 0 : fieldData.begin()->second->getCount(); }
+	size_t getHeight() const override { return 1; } // In fact, this will be only a 1-dimensional array.
 
 	const std::list<ObjectState>& getObjectStates() const { return objectStates; }
 

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -17,7 +17,14 @@
 
 RadarTrackObjectsNode::RadarTrackObjectsNode() { fieldData.emplace(XYZ_VEC3_F32, createArray<HostPinnedArray>(XYZ_VEC3_F32)); }
 
-void RadarTrackObjectsNode::setParameters() {}
+void RadarTrackObjectsNode::setParameters(float distanceThreshold, float azimuthThreshold, float elevationThreshold,
+                                          float radialSpeedThreshold)
+{
+	this->distanceThreshold = distanceThreshold;
+	this->azimuthThreshold = azimuthThreshold;
+	this->elevationThreshold = elevationThreshold;
+	this->radialSpeedThreshold = radialSpeedThreshold;
+}
 
 void RadarTrackObjectsNode::validateImpl() { IPointsNodeSingleInput::validateImpl(); }
 
@@ -40,11 +47,6 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 	};
 	std::vector<TrackedObject> trackedObjects;
 	std::vector<int> objectIndexLookup(detectionsCount, -1);
-
-	constexpr float distanceThreshold = 2.0f;
-	constexpr float azimuthThreshold = 0.1f;
-	constexpr float elevationThreshold = 0.1f;
-	constexpr float radialSpeedThreshold = 0.5f;
 
 	std::list<std::list<int>> objectIndices;
 	for (auto i = 0; i < detectionsCount; ++i) {

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Robotec.AI
+// Copyright 2024 Robotec.AI
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,14 +40,8 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 
 	objectStates.clear(); // TODO(Pawel): Remove this when we start working on tracking.
 
-	struct TrackedObject
-	{
-		Vec3f position;
-		float radialSpeed;
-	};
-	std::vector<TrackedObject> trackedObjects;
-	std::vector<int> objectIndexLookup(detectionsCount, -1);
-
+	// Top level in this list is for objects. Bottom level is for detections that belong to specific objects. Below is an initialization of a helper
+	// structure for region growing, which starts with a while-loop.
 	std::list<std::list<int>> objectIndices;
 	for (auto i = 0; i < detectionsCount; ++i) {
 		objectIndices.emplace_back(1, i);

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -91,16 +91,26 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 		}
 	}
 
+	fieldData[XYZ_VEC3_F32]->resize(objectIndices.size(), true, false);
+	auto* xyzPtr = static_cast<Vec3f*>(fieldData[XYZ_VEC3_F32]->getRawWritePtr());
+	uint32_t objectIndex = 0;
+
 	for (const auto& separateObjectIndices : objectIndices) {
 		auto& objectState = objectStates.emplace_back();
-		objectState.id = 0;
+		objectState.id = objectIndex++;
+
+		auto objectCenter = Vec3f(0.0f, 0.0f, 0.0f);
+		for (const auto index : separateObjectIndices) {
+			objectCenter += xyzHostPtr->at(index);
+		}
+		xyzPtr[objectState.id] = 1.0f / separateObjectIndices.size() * objectCenter;
 	}
 
-	std::printf("Objects count: %lu\n", objectStates.size());
+	std::printf("Objects count: %lu\n", fieldData[XYZ_VEC3_F32]->getCount());
 	std::printf("");
 }
 
 std::vector<rgl_field_t> RadarTrackObjectsNode::getRequiredFieldList() const
 {
-	return {DISTANCE_F32, AZIMUTH_F32, ELEVATION_F32, RADIAL_SPEED_F32, XYZ_VEC3_F32, POWER_F32, RCS_F32, NOISE_F32};
+	return {XYZ_VEC3_F32, DISTANCE_F32, AZIMUTH_F32, ELEVATION_F32, RADIAL_SPEED_F32};
 }

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -1,0 +1,34 @@
+// Copyright 2023 Robotec.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <graph/NodesCore.hpp>
+
+void RadarTrackObjectsNode::setParameters()
+{
+}
+
+void RadarTrackObjectsNode::validateImpl()
+{
+	IPointsNodeSingleInput::validateImpl();
+}
+
+void RadarTrackObjectsNode::enqueueExecImpl()
+{
+
+}
+
+IAnyArray::ConstPtr RadarTrackObjectsNode::getFieldData(rgl_field_t field)
+{
+	return input->getFieldData(field);
+}

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -25,7 +25,12 @@ void RadarTrackObjectsNode::validateImpl()
 
 void RadarTrackObjectsNode::enqueueExecImpl()
 {
+	
+}
 
+std::vector<rgl_field_t> RadarTrackObjectsNode::getRequiredFieldList() const
+{
+	return { DISTANCE_F32, AZIMUTH_F32, ELEVATION_F32, RADIAL_SPEED_F32, XYZ_VEC3_F32, POWER_F32, RCS_F32, NOISE_F32 };
 }
 
 IAnyArray::ConstPtr RadarTrackObjectsNode::getFieldData(rgl_field_t field)

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -103,11 +103,8 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 		for (const auto index : separateObjectIndices) {
 			objectCenter += xyzHostPtr->at(index);
 		}
-		xyzPtr[objectState.id] = 1.0f / separateObjectIndices.size() * objectCenter;
+		xyzPtr[objectState.id] = 1 / static_cast<float>(separateObjectIndices.size()) * objectCenter;
 	}
-
-	std::printf("Objects count: %lu\n", fieldData[XYZ_VEC3_F32]->getCount());
-	std::printf("");
 }
 
 std::vector<rgl_field_t> RadarTrackObjectsNode::getRequiredFieldList() const

--- a/src/math/RuningStats.hpp
+++ b/src/math/RuningStats.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 Robotec.AI
+// Copyright 2023 Robotec.AI
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,8 +23,7 @@ public:
 	static constexpr RunningStats calculateFor(const std::vector<StatType>& range)
 	{
 		RunningStats stats;
-		for (auto&& element : range)
-		{
+		for (auto&& element : range) {
 			stats.addSample(element);
 		}
 		return stats;
@@ -44,26 +43,29 @@ public:
 
 	auto getStdDev() const
 	{
+		// This if-statement is only for handling floating point numbers.
 		if constexpr (std::is_floating_point_v<StatType>) {
 			return std::sqrt(getVariance());
-		} else {
-			// I specified here only the ones that are of float type and have aliases (assuming, they are used mostly or at all).
-			const auto variance = getVariance();
-			if constexpr (std::is_same_v<StatType, Vector<2, float>>) {
-				return Vector<2, float>{std::sqrt(variance.x()), std::sqrt(variance.y())};
-			} else if constexpr (std::is_same_v<StatType, Vector<3, float>>) {
-				return Vector<3, float>{std::sqrt(variance.x()), std::sqrt(variance.y()), std::sqrt(variance.z())};
-			} else if constexpr (std::is_same_v<StatType, Vector<4, float>>) {
-				return Vector<4, float>{std::sqrt(variance[0]), std::sqrt(variance[1]), std::sqrt(variance[2]),
-				                        std::sqrt(variance[3])};
-			}
+		}
+
+		// If-statement below all handle Vector types.
+		const auto variance = getVariance();
+
+		if constexpr (std::is_same_v<StatType, Vector<2, float>>) {
+			return Vector<2, float>{std::sqrt(variance.x()), std::sqrt(variance.y())};
+		}
+
+		if constexpr (std::is_same_v<StatType, Vector<3, float>>) {
+			return Vector<3, float>{std::sqrt(variance.x()), std::sqrt(variance.y()), std::sqrt(variance.z())};
+		}
+
+		if constexpr (std::is_same_v<StatType, Vector<4, float>>) {
+			return Vector<4, float>{std::sqrt(variance[0]), std::sqrt(variance[1]), std::sqrt(variance[2]),
+			                        std::sqrt(variance[3])};
 		}
 	}
 
-	auto getMeanAndStdDev() const
-	{
-		return std::make_pair(getMean(), getStdDev());
-	}
+	auto getMeanAndStdDev() const { return std::make_pair(getMean(), getStdDev()); }
 
 private:
 	size_t counter{0};

--- a/src/math/RuningStats.hpp
+++ b/src/math/RuningStats.hpp
@@ -1,0 +1,72 @@
+// Copyright 2022 Robotec.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Integral types here generally make no sense in terms of mean and std dev.
+// I would force users to use floats, to eliminate possible errors.
+template<typename StatType, typename = std::enable_if_t<!std::is_integral_v<StatType>>>
+class RunningStats
+{
+public:
+	static constexpr RunningStats calculateFor(const std::vector<StatType>& range)
+	{
+		RunningStats stats;
+		for (auto&& element : range)
+		{
+			stats.addSample(element);
+		}
+		return stats;
+	}
+
+	void addSample(StatType sample)
+	{
+		++counter;
+		StatType delta = sample - mean;
+		mean += delta / counter;
+		m2 += delta * (sample - mean);
+	}
+
+	StatType getMean() const { return mean; }
+
+	StatType getVariance() const { return counter < 2 ? StatType{} : m2 / counter; }
+
+	auto getStdDev() const
+	{
+		if constexpr (std::is_floating_point_v<StatType>) {
+			return std::sqrt(getVariance());
+		} else {
+			// I specified here only the ones that are of float type and have aliases (assuming, they are used mostly or at all).
+			const auto variance = getVariance();
+			if constexpr (std::is_same_v<StatType, Vector<2, float>>) {
+				return Vector<2, float>{std::sqrt(variance.x()), std::sqrt(variance.y())};
+			} else if constexpr (std::is_same_v<StatType, Vector<3, float>>) {
+				return Vector<3, float>{std::sqrt(variance.x()), std::sqrt(variance.y()), std::sqrt(variance.z())};
+			} else if constexpr (std::is_same_v<StatType, Vector<4, float>>) {
+				return Vector<4, float>{std::sqrt(variance[0]), std::sqrt(variance[1]), std::sqrt(variance[2]),
+				                        std::sqrt(variance[3])};
+			}
+		}
+	}
+
+	auto getMeanAndStdDev() const
+	{
+		return std::make_pair(getMean(), getStdDev());
+	}
+
+private:
+	size_t counter{0};
+	StatType mean{0};
+	StatType m2{0};
+};

--- a/src/math/Vector.hpp
+++ b/src/math/Vector.hpp
@@ -44,7 +44,8 @@ struct Vector
 	Vector(const std::array<T, dim>& values) { std::copy(values.begin(), values.end(), row); }
 
 	// List constructor
-	template<typename... Args>
+	template<typename... Args,
+	    typename = typename std::enable_if<sizeof...(Args) >= 2>::type>
 	HostDevFn Vector(Args... args) : row{static_cast<T>(args)...}
 	{
 		static_assert(sizeof...(Args) == dim);

--- a/src/tape/TapeCore.hpp
+++ b/src/tape/TapeCore.hpp
@@ -62,6 +62,7 @@ class TapeCore
 	static void tape_node_points_from_array(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_filter_ground(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_radar_postprocess(const YAML::Node& yamlNode, PlaybackState& state);
+	static void tape_node_points_radar_track_objects(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_gaussian_noise_angular_ray(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_gaussian_noise_angular_hitpoint(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_gaussian_noise_distance(const YAML::Node& yamlNode, PlaybackState& state);
@@ -113,6 +114,7 @@ class TapeCore
 		    TAPE_CALL_MAPPING("rgl_node_points_from_array", TapeCore::tape_node_points_from_array),
 		    TAPE_CALL_MAPPING("rgl_node_points_filter_ground", TapeCore::tape_node_points_filter_ground),
 		    TAPE_CALL_MAPPING("rgl_node_points_radar_postprocess", TapeCore::tape_node_points_radar_postprocess),
+		    TAPE_CALL_MAPPING("rgl_node_points_radar_track_objects", TapeCore::tape_node_points_radar_track_objects),
 		    TAPE_CALL_MAPPING("rgl_node_gaussian_noise_angular_ray", TapeCore::tape_node_gaussian_noise_angular_ray),
 		    TAPE_CALL_MAPPING("rgl_node_gaussian_noise_angular_hitpoint", TapeCore::tape_node_gaussian_noise_angular_hitpoint),
 		    TAPE_CALL_MAPPING("rgl_node_gaussian_noise_distance", TapeCore::tape_node_gaussian_noise_distance),

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set(RGL_TEST_FILES
     src/graph/nodes/GaussianNoiseDistanceNodeTest.cpp
     src/graph/nodes/RaytraceNodeTest.cpp
     src/graph/nodes/RadarPostprocessPointsNodeTest.cpp
+    src/graph/nodes/RadarTrackObjectsNodeTest.cpp
     src/graph/nodes/SetRingIdsRaysNodeTest.cpp
     src/graph/nodes/SetTimeOffsetsRaysNodeTest.cpp
     src/graph/nodes/SpatialMergePointsNodeTest.cpp

--- a/test/src/TapeTest.cpp
+++ b/test/src/TapeTest.cpp
@@ -269,7 +269,7 @@ TEST_F(TapeTest, RecordPlayAllCalls)
 	    rgl_node_points_radar_postprocess(&radarPostprocess, &radarScope, 1, 1.0f, 1.0f, 79E9f, 31.0f, 27.0f, 60.0f, 1.0f));
 
 	rgl_node_t radarTrackObjects = nullptr;
-	EXPECT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&radarTrackObjects));
+	EXPECT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&radarTrackObjects, 2.0f, 0.1f, 0.1f, 0.5f));
 
 	rgl_node_t filterGround = nullptr;
 	rgl_vec3f sensorUpVector = {0.0f, 1.0f, 0.0f};

--- a/test/src/TapeTest.cpp
+++ b/test/src/TapeTest.cpp
@@ -268,6 +268,9 @@ TEST_F(TapeTest, RecordPlayAllCalls)
 	EXPECT_RGL_SUCCESS(
 	    rgl_node_points_radar_postprocess(&radarPostprocess, &radarScope, 1, 1.0f, 1.0f, 79E9f, 31.0f, 27.0f, 60.0f, 1.0f));
 
+	rgl_node_t radarTrackObjects = nullptr;
+	EXPECT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&radarTrackObjects));
+
 	rgl_node_t filterGround = nullptr;
 	rgl_vec3f sensorUpVector = {0.0f, 1.0f, 0.0f};
 	EXPECT_RGL_SUCCESS(rgl_node_points_filter_ground(&filterGround, &sensorUpVector, 0.1f));

--- a/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
+++ b/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
@@ -1,0 +1,13 @@
+#include <helpers/testPointCloud.hpp>
+
+#include <api/apiCommon.hpp>
+
+class RadarTrackObjectsNodeTest : public RGLTest
+{};
+
+TEST_F(RadarTrackObjectsNodeTest, creating_objects_test)
+{
+	// Setup objects tracking node
+	rgl_node_t trackObjectsNode = nullptr;
+	ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
+}

--- a/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
+++ b/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
@@ -90,15 +90,19 @@ void generateRandomDetectionClusters(TestPointCloud& pointCloud, size_t clusterC
 TEST_F(RadarTrackObjectsNodeTest, objects_number_test)
 {
 	std::vector<rgl_field_t> fields{XYZ_VEC3_F32};
+	constexpr float distanceThreshold = 2.0f;
+	constexpr float azimuthThreshold = 0.1f;
+	constexpr float elevationThreshold = 0.1f;
+	constexpr float radialSpeedThreshold = 0.5f;
 
 	// Setup objects tracking node
 	rgl_node_t trackObjectsNode = nullptr;
-	ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
+	ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode, distanceThreshold, azimuthThreshold,
+	                                                       elevationThreshold, radialSpeedThreshold));
 
 	constexpr size_t objectsCount = 5;
 	constexpr size_t detectionsCountPerObject = 10;
-	std::vector<rgl_field_t> pointFields =
-	    Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
+	std::vector<rgl_field_t> pointFields = Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
 	TestPointCloud inPointCloud(pointFields, objectsCount * detectionsCountPerObject);
 
 	generateFixedDetectionClusters(inPointCloud, objectsCount, detectionsCountPerObject);
@@ -119,13 +123,18 @@ TEST_F(RadarTrackObjectsNodeTest, creating_random_objects_test)
 	GTEST_SKIP_("Debug test on development stage.");
 
 	std::vector<rgl_field_t> fields{XYZ_VEC3_F32};
+	constexpr float distanceThreshold = 2.0f;
+	constexpr float azimuthThreshold = 0.1f;
+	constexpr float elevationThreshold = 0.1f;
+	constexpr float radialSpeedThreshold = 0.5f;
 	size_t iterationCounter = 0;
 
 	while (true) {
 		// Setup objects tracking node
 		rgl_node_t trackObjectsNode = nullptr, ros2DetectionsNode = nullptr, ros2ObjectsNode = nullptr,
 		           detectionsFormat = nullptr, objectsFormat = nullptr;
-		ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
+		ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode, distanceThreshold, azimuthThreshold,
+		                                                       elevationThreshold, radialSpeedThreshold));
 		ASSERT_RGL_SUCCESS(rgl_node_points_ros2_publish(&ros2DetectionsNode, "radar_detections", "world"));
 		ASSERT_RGL_SUCCESS(rgl_node_points_ros2_publish(&ros2ObjectsNode, "radar_objects", "world"));
 		ASSERT_RGL_SUCCESS(rgl_node_points_format(&detectionsFormat, fields.data(), fields.size()));

--- a/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
+++ b/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
@@ -1,13 +1,49 @@
+#include <api/apiCommon.hpp>
 #include <helpers/testPointCloud.hpp>
 
-#include <api/apiCommon.hpp>
+#include <random>
 
 class RadarTrackObjectsNodeTest : public RGLTest
 {};
+
+template <float MinV, float MaxV>
+float getRandomValue()
+{
+	const static auto seed = std::random_device{}();
+	static std::mt19937 generator(seed);
+	static std::uniform_real_distribution<float> distribution(MinV, MaxV);
+
+	return distribution(generator);
+};
+
+template <rgl_field_t FieldName, float MinV, float MaxV>
+void SetFieldValues(TestPointCloud& pointCloud, size_t pointsCount)
+{
+	std::vector<typename Field<FieldName>::type> fields;
+	std::generate_n(std::back_inserter(fields), pointsCount, [&]() { return getRandomValue<MinV, MaxV>(); });
+	pointCloud.setFieldValues<FieldName>(fields);
+}
 
 TEST_F(RadarTrackObjectsNodeTest, creating_objects_test)
 {
 	// Setup objects tracking node
 	rgl_node_t trackObjectsNode = nullptr;
 	ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
+
+	const size_t pointsCount = 2;
+	std::vector<rgl_field_t> pointFields = Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
+	TestPointCloud inPointCloud(pointFields, pointsCount);
+
+	SetFieldValues<DISTANCE_F32, 5.0f, 6.0f>(inPointCloud, pointsCount);
+	SetFieldValues<AZIMUTH_F32, -10.0f, 10.0f>(inPointCloud, pointsCount);
+	SetFieldValues<ELEVATION_F32, -5.0f, 5.0f>(inPointCloud, pointsCount);
+	SetFieldValues<RADIAL_SPEED_F32, -5.0f, 5.0f>(inPointCloud, pointsCount);
+	inPointCloud.setFieldValues<XYZ_VEC3_F32>(generateFieldValues(pointsCount, genCoord));
+	SetFieldValues<POWER_F32, 90.0f, 130.0f>(inPointCloud, pointsCount);
+	SetFieldValues<RCS_F32, 10.0f, 30.0f>(inPointCloud, pointsCount);
+	SetFieldValues<NOISE_F32, 80.0f, 100.0f>(inPointCloud, pointsCount);
+
+	const auto usePointsNode = inPointCloud.createUsePointsNode();
+	EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, trackObjectsNode));
+	EXPECT_RGL_SUCCESS(rgl_graph_run(trackObjectsNode));
 }

--- a/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
+++ b/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
@@ -1,49 +1,122 @@
 #include <api/apiCommon.hpp>
 #include <helpers/testPointCloud.hpp>
+#include <rgl/api/extensions/ros2.h>
 
 #include <random>
+#include <ranges>
 
 class RadarTrackObjectsNodeTest : public RGLTest
 {};
 
-template <float MinV, float MaxV>
-float getRandomValue()
+template<typename Type, Type MinV, Type MaxV>
+Type getRandomValue()
 {
-	const static auto seed = std::random_device{}();
-	static std::mt19937 generator(seed);
+	static_assert(std::is_arithmetic_v<Type>, "Template arguments are not numbers.");
 	static std::uniform_real_distribution<float> distribution(MinV, MaxV);
 
-	return distribution(generator);
-};
+	const auto seed = std::random_device{}();
+	std::mt19937 generator(seed);
 
-template <rgl_field_t FieldName, float MinV, float MaxV>
-void SetFieldValues(TestPointCloud& pointCloud, size_t pointsCount)
+	return distribution(generator);
+}
+
+Vec3f getRandomVector()
 {
-	std::vector<typename Field<FieldName>::type> fields;
-	std::generate_n(std::back_inserter(fields), pointsCount, [&]() { return getRandomValue<MinV, MaxV>(); });
-	pointCloud.setFieldValues<FieldName>(fields);
+	std::uniform_real_distribution<> distribution(0, 2 * M_PI);
+
+	const auto seed = std::random_device{}();
+	std::mt19937 generator(seed);
+
+	double theta = distribution(generator), phi = distribution(generator);
+	return Vec3f{std::sin(theta) * std::cos(phi), std::sin(theta) * std::sin(phi), std::cos(theta)};
+}
+
+void GenerateDetectionClusters(TestPointCloud& pointCloud, size_t clusterCount, size_t clusterPointsCount)
+{
+	constexpr float centerScale = 10.0f;
+	constexpr float centerXOffset = 20.0f;
+
+	std::vector<Vec3f> clusterCenters;
+	std::generate_n(std::back_inserter(clusterCenters), clusterCount, getRandomVector);
+
+	std::vector<Vec3f> xyz;
+	std::vector<float> distance;
+	std::vector<float> azimuth;
+	std::vector<float> elevation;
+	std::vector<float> radialSpeed;
+
+	for (const auto& clusterCenter : std::views::transform(clusterCenters, [=](auto center) {
+		     center *= centerScale;
+		     center[0] = center[0] + centerXOffset;
+		     return center;
+	     })) {
+		const auto clusterXYZ = generateFieldValues(clusterPointsCount, genNormal);
+		for (const auto& detectionXYZ : clusterXYZ) {
+			const auto worldXYZ = detectionXYZ + clusterCenter;
+
+			xyz.emplace_back(worldXYZ);
+			distance.emplace_back(worldXYZ.length());
+
+			const auto worldSph = worldXYZ.toSpherical();
+			azimuth.emplace_back(worldSph[1]);
+			elevation.emplace_back(worldSph[2]);
+
+			radialSpeed.emplace_back(getRandomValue<float, 4.8f, 5.2f>());
+		}
+	}
+
+	pointCloud.setFieldValues<XYZ_VEC3_F32>(xyz);
+	pointCloud.setFieldValues<DISTANCE_F32>(distance);
+	pointCloud.setFieldValues<AZIMUTH_F32>(azimuth);
+	pointCloud.setFieldValues<ELEVATION_F32>(elevation);
+	pointCloud.setFieldValues<RADIAL_SPEED_F32>(radialSpeed);
+
+	std::printf("");
 }
 
 TEST_F(RadarTrackObjectsNodeTest, creating_objects_test)
 {
-	// Setup objects tracking node
-	rgl_node_t trackObjectsNode = nullptr;
-	ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
+	GTEST_SKIP_("Debug test on development stage.");
 
-	const size_t pointsCount = 2;
-	std::vector<rgl_field_t> pointFields = Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
-	TestPointCloud inPointCloud(pointFields, pointsCount);
+	std::vector<rgl_field_t> fields{XYZ_VEC3_F32};
+	size_t iterationCounter = 0;
 
-	SetFieldValues<DISTANCE_F32, 5.0f, 6.0f>(inPointCloud, pointsCount);
-	SetFieldValues<AZIMUTH_F32, -10.0f, 10.0f>(inPointCloud, pointsCount);
-	SetFieldValues<ELEVATION_F32, -5.0f, 5.0f>(inPointCloud, pointsCount);
-	SetFieldValues<RADIAL_SPEED_F32, -5.0f, 5.0f>(inPointCloud, pointsCount);
-	inPointCloud.setFieldValues<XYZ_VEC3_F32>(generateFieldValues(pointsCount, genCoord));
-	SetFieldValues<POWER_F32, 90.0f, 130.0f>(inPointCloud, pointsCount);
-	SetFieldValues<RCS_F32, 10.0f, 30.0f>(inPointCloud, pointsCount);
-	SetFieldValues<NOISE_F32, 80.0f, 100.0f>(inPointCloud, pointsCount);
+	while (true) {
+		// Setup objects tracking node
+		rgl_node_t trackObjectsNode = nullptr, ros2DetectionsNode = nullptr, ros2ObjectsNode = nullptr, detectionsFormat = nullptr,
+		           objectsFormat = nullptr;
+		ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
+		ASSERT_RGL_SUCCESS(rgl_node_points_ros2_publish(&ros2DetectionsNode, "radar_detections", "world"));
+		ASSERT_RGL_SUCCESS(rgl_node_points_ros2_publish(&ros2ObjectsNode, "radar_objects", "world"));
+		ASSERT_RGL_SUCCESS(rgl_node_points_format(&detectionsFormat, fields.data(), fields.size()));
+		ASSERT_RGL_SUCCESS(rgl_node_points_format(&objectsFormat, fields.data(), fields.size()));
 
-	const auto usePointsNode = inPointCloud.createUsePointsNode();
-	EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, trackObjectsNode));
-	EXPECT_RGL_SUCCESS(rgl_graph_run(trackObjectsNode));
+		const size_t objectsCount = getRandomValue<int, 5, 10>();
+		const size_t detectionsCountPerObject = getRandomValue<int, 10, 20>();
+		std::vector<rgl_field_t> pointFields = Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
+		TestPointCloud inPointCloud(pointFields, objectsCount * detectionsCountPerObject);
+
+		GenerateDetectionClusters(inPointCloud, objectsCount, detectionsCountPerObject);
+
+		const auto usePointsNode = inPointCloud.createUsePointsNode();
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, trackObjectsNode));
+
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, detectionsFormat));
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(detectionsFormat, ros2DetectionsNode));
+
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(trackObjectsNode, objectsFormat));
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(objectsFormat, ros2ObjectsNode));
+
+		EXPECT_RGL_SUCCESS(rgl_graph_run(trackObjectsNode));
+		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+		int32_t detectedObjectsCount = 0, objectsSize = 0;
+		rgl_graph_get_result_size(trackObjectsNode, fields.at(0), &detectedObjectsCount, &objectsSize);
+
+		if (detectedObjectsCount != objectsCount) {
+			printf("[%lu] Detected / given objects: %d / %lu\n", iterationCounter++, detectedObjectsCount, objectsCount);
+		}
+
+		EXPECT_RGL_SUCCESS(rgl_cleanup());
+	}
 }

--- a/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
+++ b/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
@@ -1,9 +1,7 @@
 #include <api/apiCommon.hpp>
 #include <helpers/testPointCloud.hpp>
-#include <rgl/api/extensions/ros2.h>
 
 #include <random>
-#include <ranges>
 
 
 class RadarTrackObjectsNodeTest : public RGLTest
@@ -114,6 +112,8 @@ TEST_F(RadarTrackObjectsNodeTest, objects_number_test)
 	ASSERT_TRUE(detectedObjectsCount == objectsCount);
 }
 
+#if RGL_BUILD_ROS2_EXTENSION
+#include <rgl/api/extensions/ros2.h>
 TEST_F(RadarTrackObjectsNodeTest, creating_random_objects_test)
 {
 	GTEST_SKIP_("Debug test on development stage.");
@@ -161,3 +161,4 @@ TEST_F(RadarTrackObjectsNodeTest, creating_random_objects_test)
 		EXPECT_RGL_SUCCESS(rgl_cleanup());
 	}
 }
+#endif

--- a/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
+++ b/test/src/graph/nodes/RadarTrackObjectsNodeTest.cpp
@@ -5,6 +5,7 @@
 #include <random>
 #include <ranges>
 
+
 class RadarTrackObjectsNodeTest : public RGLTest
 {};
 
@@ -31,25 +32,15 @@ Vec3f getRandomVector()
 	return Vec3f{std::sin(theta) * std::cos(phi), std::sin(theta) * std::sin(phi), std::cos(theta)};
 }
 
-void GenerateDetectionClusters(TestPointCloud& pointCloud, size_t clusterCount, size_t clusterPointsCount)
+void generateDetectionClusters(TestPointCloud& pointCloud, const std::vector<Vec3f>& clusterCenters, size_t clusterPointsCount)
 {
-	constexpr float centerScale = 10.0f;
-	constexpr float centerXOffset = 20.0f;
-
-	std::vector<Vec3f> clusterCenters;
-	std::generate_n(std::back_inserter(clusterCenters), clusterCount, getRandomVector);
-
 	std::vector<Vec3f> xyz;
 	std::vector<float> distance;
 	std::vector<float> azimuth;
 	std::vector<float> elevation;
 	std::vector<float> radialSpeed;
 
-	for (const auto& clusterCenter : std::views::transform(clusterCenters, [=](auto center) {
-		     center *= centerScale;
-		     center[0] = center[0] + centerXOffset;
-		     return center;
-	     })) {
+	for (const auto clusterCenter : clusterCenters) {
 		const auto clusterXYZ = generateFieldValues(clusterPointsCount, genNormal);
 		for (const auto& detectionXYZ : clusterXYZ) {
 			const auto worldXYZ = detectionXYZ + clusterCenter;
@@ -70,11 +61,60 @@ void GenerateDetectionClusters(TestPointCloud& pointCloud, size_t clusterCount, 
 	pointCloud.setFieldValues<AZIMUTH_F32>(azimuth);
 	pointCloud.setFieldValues<ELEVATION_F32>(elevation);
 	pointCloud.setFieldValues<RADIAL_SPEED_F32>(radialSpeed);
-
-	std::printf("");
 }
 
-TEST_F(RadarTrackObjectsNodeTest, creating_objects_test)
+void generateFixedDetectionClusters(TestPointCloud& pointCloud, size_t clusterCount, size_t clusterPointsCount)
+{
+	constexpr float centerScale = 10.0f;
+	const Vec3f centerXOffset = Vec3f{20.0f, 0.0f, 0.0f};
+
+	std::vector<Vec3f> clusterCenters;
+	for (int i = 0; i < clusterCount; ++i) {
+		const auto angle = i * 2 * M_PI / static_cast<double>(clusterCount);
+		clusterCenters.emplace_back(Vec3f{std::cos(angle), std::sin(angle), 0.0f} * centerScale);
+	}
+
+	generateDetectionClusters(pointCloud, clusterCenters, clusterPointsCount);
+}
+
+void generateRandomDetectionClusters(TestPointCloud& pointCloud, size_t clusterCount, size_t clusterPointsCount)
+{
+	constexpr float centerScale = 10.0f;
+	const Vec3f centerOffset = Vec3f{20.0f, 0.0f, 0.0f};
+
+	std::vector<Vec3f> clusterCenters;
+	std::generate_n(std::back_inserter(clusterCenters), clusterCount,
+	                [&]() { return getRandomVector() * centerScale + centerOffset; });
+
+	generateDetectionClusters(pointCloud, clusterCenters, clusterPointsCount);
+}
+
+TEST_F(RadarTrackObjectsNodeTest, objects_number_test)
+{
+	std::vector<rgl_field_t> fields{XYZ_VEC3_F32};
+
+	// Setup objects tracking node
+	rgl_node_t trackObjectsNode = nullptr;
+	ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
+
+	constexpr size_t objectsCount = 5;
+	constexpr size_t detectionsCountPerObject = 10;
+	std::vector<rgl_field_t> pointFields =
+	    Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
+	TestPointCloud inPointCloud(pointFields, objectsCount * detectionsCountPerObject);
+
+	generateFixedDetectionClusters(inPointCloud, objectsCount, detectionsCountPerObject);
+
+	const auto usePointsNode = inPointCloud.createUsePointsNode();
+	ASSERT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, trackObjectsNode));
+	ASSERT_RGL_SUCCESS(rgl_graph_run(trackObjectsNode));
+
+	int32_t detectedObjectsCount = 0, objectsSize = 0;
+	rgl_graph_get_result_size(trackObjectsNode, fields.at(0), &detectedObjectsCount, &objectsSize);
+	ASSERT_TRUE(detectedObjectsCount == objectsCount);
+}
+
+TEST_F(RadarTrackObjectsNodeTest, creating_random_objects_test)
 {
 	GTEST_SKIP_("Debug test on development stage.");
 
@@ -83,8 +123,8 @@ TEST_F(RadarTrackObjectsNodeTest, creating_objects_test)
 
 	while (true) {
 		// Setup objects tracking node
-		rgl_node_t trackObjectsNode = nullptr, ros2DetectionsNode = nullptr, ros2ObjectsNode = nullptr, detectionsFormat = nullptr,
-		           objectsFormat = nullptr;
+		rgl_node_t trackObjectsNode = nullptr, ros2DetectionsNode = nullptr, ros2ObjectsNode = nullptr,
+		           detectionsFormat = nullptr, objectsFormat = nullptr;
 		ASSERT_RGL_SUCCESS(rgl_node_points_radar_track_objects(&trackObjectsNode));
 		ASSERT_RGL_SUCCESS(rgl_node_points_ros2_publish(&ros2DetectionsNode, "radar_detections", "world"));
 		ASSERT_RGL_SUCCESS(rgl_node_points_ros2_publish(&ros2ObjectsNode, "radar_objects", "world"));
@@ -93,21 +133,22 @@ TEST_F(RadarTrackObjectsNodeTest, creating_objects_test)
 
 		const size_t objectsCount = getRandomValue<int, 5, 10>();
 		const size_t detectionsCountPerObject = getRandomValue<int, 10, 20>();
-		std::vector<rgl_field_t> pointFields = Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
+		std::vector<rgl_field_t> pointFields =
+		    Node::validatePtr<RadarTrackObjectsNode>(trackObjectsNode)->getRequiredFieldList();
 		TestPointCloud inPointCloud(pointFields, objectsCount * detectionsCountPerObject);
 
-		GenerateDetectionClusters(inPointCloud, objectsCount, detectionsCountPerObject);
+		generateRandomDetectionClusters(inPointCloud, objectsCount, detectionsCountPerObject);
 
 		const auto usePointsNode = inPointCloud.createUsePointsNode();
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, trackObjectsNode));
+		ASSERT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, trackObjectsNode));
 
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, detectionsFormat));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(detectionsFormat, ros2DetectionsNode));
+		ASSERT_RGL_SUCCESS(rgl_graph_node_add_child(usePointsNode, detectionsFormat));
+		ASSERT_RGL_SUCCESS(rgl_graph_node_add_child(detectionsFormat, ros2DetectionsNode));
 
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(trackObjectsNode, objectsFormat));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(objectsFormat, ros2ObjectsNode));
+		ASSERT_RGL_SUCCESS(rgl_graph_node_add_child(trackObjectsNode, objectsFormat));
+		ASSERT_RGL_SUCCESS(rgl_graph_node_add_child(objectsFormat, ros2ObjectsNode));
 
-		EXPECT_RGL_SUCCESS(rgl_graph_run(trackObjectsNode));
+		ASSERT_RGL_SUCCESS(rgl_graph_run(trackObjectsNode));
 		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
 		int32_t detectedObjectsCount = 0, objectsSize = 0;


### PR DESCRIPTION
Introduces RadarTrackObjectsNode, that should be placed right after RadarPostprocessPointsNode. It takes radar detections and groups them into objects. Provides XYZ output that contain object centers. Additionally, public method is provided for this node, that return list of object state structures. With current implementation, object states contain mostly mockup data.