### PR TITLE
Set log level prior to logging Log config info

### DIFF
--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -49,12 +49,11 @@ void Logger::configure(rgl_log_level_t logLevel, std::optional<std::filesystem::
 	}
 
 	mainLogger = std::make_shared<spdlog::logger>("RGL", sinkList.begin(), sinkList.end());
-	mainLogger->set_level(spdlog::level::info); // Print logging configuration as INFO
+	mainLogger->set_level(static_cast<spdlog::level::level_enum>(logLevel));
 	mainLogger->set_pattern("[%c]: %v");
 	mainLogger->info("Logging configured: level={}, file={}, stdout={}",
 	                 spdlog::level::to_string_view(static_cast<spdlog::level::level_enum>(logLevel)),
 	                 logFilePath.has_value() ? logFilePath.value().string() : "(disabled)", useStdout);
 	// https://spdlog.docsforge.com/master/3.custom-formatting/#pattern-flags
 	mainLogger->set_pattern("[%T][%6i us][%l]: %v");
-	mainLogger->set_level(static_cast<spdlog::level::level_enum>(logLevel));
 }


### PR DESCRIPTION
With the current behavior, the text `Logging configured: ...` is always logged once, even when RGL is built with RGL_LOG_LEVEL_OFF, and even when the first call to RGL is `rgl_configure_logging(RGL_LOG_LEVEL_OFF,..)` since Logger::getOrCreate() is called, which in turn calls the default constructor which in tern calls Logger::configure with the settings used when RGL was built, and the log level is overriden to `spdlog::level::info` before writing the `Logging configured: ...` message.

This is a problem for any application using RGL which does not have a file path to log to (and therefore cannot set `useStdout` false).

This PR makes it so that the log level is set before logging the `Logging configured: ...` message.
This ensures that if RGL is built with e.g. RGL_LOG_LEVEL_WARN, the `Logging configured: ...` message is not shown.

A proper solution to all of this might be to not call Logger::configure from the default constructor at all, or make the constructor take log level etc as input parameters. That was a little over my head, so instead I fixed this simpler case which to me is just a pure bug.

