### PR TITLE
v17 O3DE integration hotfix

### DIFF
--- a/docs/Ros2Extension.md
+++ b/docs/Ros2Extension.md
@@ -31,6 +31,7 @@ For some, the process has been automated - run `setup.py --install-ros2-deps` to
     ```bash
     apt install -y ros-${ROS_DISTRO}-cyclonedds ros-${ROS_DISTRO}-rmw-cyclonedds-cpp
     apt install -y ros-${ROS_DISTRO}-fastrtps ros-${ROS_DISTRO}-rmw-fastrtps-cpp
+    apt install -y ros-${ROS_DISTRO}-radar-msgs
     apt install patchelf
     ```
 

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -809,16 +809,6 @@ RGL_API rgl_status_t rgl_node_points_format(rgl_node_t* node, const rgl_field_t*
 RGL_API rgl_status_t rgl_node_points_yield(rgl_node_t* node, const rgl_field_t* fields, int32_t field_count);
 
 /**
- * Creates or modifies CompactPointsNode.
- * The Node removes non-hit points. In other words, it converts a point cloud into a dense one.
- * Graph input: point cloud
- * Graph output: point cloud (compacted)
- * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.
- */
-[[deprecated("Use rgl_node_points_compact_by_field(rgl_node_t* node, rgl_field_t field) instead.")]] RGL_API rgl_status_t
-rgl_node_points_compact(rgl_node_t* node);
-
-/**
  * Creates or modifies CompactPointsByFieldNode.
  * The Node removes points if the given field is set to a non-zero value.
  * Currently supported fields are RGL_FIELD_IS_HIT_I32 and RGL_FIELD_IS_GROUND_I32.

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -815,7 +815,7 @@ RGL_API rgl_status_t rgl_node_points_yield(rgl_node_t* node, const rgl_field_t* 
  * Graph output: point cloud (compacted)
  * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.
  */
-RGL_API [[deprecated("Use rgl_node_points_compact_by_field(rgl_node_t* node, rgl_field_t field) instead.")]] rgl_status_t
+[[deprecated("Use rgl_node_points_compact_by_field(rgl_node_t* node, rgl_field_t field) instead.")]] RGL_API rgl_status_t
 rgl_node_points_compact(rgl_node_t* node);
 
 /**

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1046,26 +1046,6 @@ void TapeCore::tape_node_points_yield(const YAML::Node& yamlNode, PlaybackState&
 	state.nodes.insert({nodeId, node});
 }
 
-RGL_API rgl_status_t rgl_node_points_compact(rgl_node_t* node)
-{
-	auto status = rglSafeCall([&]() {
-		RGL_API_LOG("rgl_node_points_compact(node={})", repr(node));
-		CHECK_ARG(node != nullptr);
-
-		createOrUpdateNode<CompactByFieldPointsNode>(node, RGL_FIELD_IS_HIT_I32);
-	});
-	TAPE_HOOK(node);
-	return status;
-}
-
-void TapeCore::tape_node_points_compact(const YAML::Node& yamlNode, PlaybackState& state)
-{
-	auto nodeId = yamlNode[0].as<TapeAPIObjectID>();
-	rgl_node_t node = state.nodes.contains(nodeId) ? state.nodes.at(nodeId) : nullptr;
-	rgl_node_points_compact(&node);
-	state.nodes.insert({nodeId, node});
-}
-
 RGL_API rgl_status_t rgl_node_points_compact_by_field(rgl_node_t* node, rgl_field_t field)
 {
 	auto status = rglSafeCall([&]() {

--- a/src/tape/TapeCore.hpp
+++ b/src/tape/TapeCore.hpp
@@ -59,7 +59,6 @@ class TapeCore
 	static void tape_node_raytrace_configure_default_intensity(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_format(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_yield(const YAML::Node& yamlNode, PlaybackState& state);
-	static void tape_node_points_compact(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_compact_by_field(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_spatial_merge(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_temporal_merge(const YAML::Node& yamlNode, PlaybackState& state);
@@ -119,7 +118,6 @@ class TapeCore
 		                      TapeCore::tape_node_raytrace_configure_default_intensity),
 		    TAPE_CALL_MAPPING("rgl_node_points_format", TapeCore::tape_node_points_format),
 		    TAPE_CALL_MAPPING("rgl_node_points_yield", TapeCore::tape_node_points_yield),
-		    TAPE_CALL_MAPPING("rgl_node_points_compact", TapeCore::tape_node_points_compact),
 		    TAPE_CALL_MAPPING("rgl_node_points_compact_by_field", TapeCore::tape_node_points_compact_by_field),
 		    TAPE_CALL_MAPPING("rgl_node_points_spatial_merge", TapeCore::tape_node_points_spatial_merge),
 		    TAPE_CALL_MAPPING("rgl_node_points_temporal_merge", TapeCore::tape_node_points_temporal_merge),


### PR DESCRIPTION
**This pr:**
  - Moves the `deprecated` attribute before the `RGL_API` macro, which previously failed due to a compiler error.
  - Adds additional installation instruction related to the `radar-msgs` ros2 package dependency.