### PR TITLE
Update multi-return for more types of return and all RGL fields.

### DIFF
--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -816,6 +816,18 @@ RGL_API rgl_status_t rgl_node_raytrace_configure_beam_divergence(rgl_node_t node
 RGL_API rgl_status_t rgl_node_raytrace_configure_default_intensity(rgl_node_t node, float default_intensity);
 
 /**
+ * Modifies RaytraceNode to set return mode.
+ * Point return types (RGL_FIELD_RETURN_TYPE_U8) will be set to corresponding rgl_return_type_t values, e.g. return mode
+ * RGL_RETURN_FIRST_LAST will result in point return types to be set to RGL_RETURN_TYPE_FIRST or RGL_RETURN_TYPE_LAST,
+ * interchangeably.
+ * Default return mode on RaytraceNode is RGL_RETURN_FIRST.
+ * Passing RGL_RETURN_MODE_UNDEFINED will have no effect (does not change return mode).
+ * @param node RaytraceNode to modify.
+ * @param return_mode Return mode to set.
+ */
+RGL_API rgl_status_t rgl_node_raytrace_configure_return_mode(rgl_node_t node, rgl_return_mode_t return_mode);
+
+/**
  * Creates or modifies FormatPointsNode.
  * The Node converts internal representation into a binary format defined by the `fields` array.
  * Note: It is the user's responsibility to ensure proper data structure alignment. See (https://en.wikipedia.org/wiki/Data_structure_alignment).

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -1068,17 +1068,6 @@ RGL_API rgl_status_t rgl_node_gaussian_noise_distance(rgl_node_t* node, float me
                                                       float st_dev_rise_per_meter);
 
 /**
- * Creates or modifies MultiReturnSwitchNode
- * This is a special node which does not modify the data but acts as an adapter to the multi-return feature.
- * Thanks to this node, user can attach unchanged pipelines to work with specific return type from multi-return raytracing.
- * Graph input: point cloud (with multi-return fields)
- * Graph output: point cloud (with a selected field from parent's multi-return point cloud)
- * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.
- * @param return_type Return type to select from multi-return point cloud.
- */
-RGL_API rgl_status_t rgl_node_multi_return_switch(rgl_node_t* node, rgl_return_type_t);
-
-/**
  * Assigns value true to out_alive if the given node is known and has not been destroyed,
  * assigns value false otherwise.
  * @param node Node to check if alive

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -423,43 +423,57 @@ typedef enum : int32_t
 } rgl_field_t;
 
 /**
+ * Bitshift and masks for coding return modes and types. Most significant byte encodes the number of returns. Return mode is
+ * encoded on 8 most significant bits (24-31) - 1 for single return mode, 2 for dual return. Remaining 24 bits are for encoding
+ * return type. First return is on 8 LEAST significant bits (0-7), and next 8 bits (8-15) are for second return. Bits 16-23 are
+ * not used at this moment - in the future e.g. the third return may be encoded there. Return type comes from rgl_return_type_t.
+ * Example: RGL_RETURN_LAST_STRONGEST would be encoded as:
+ * 		0x02000201
+ * 			02 - dual return
+ * 			00 - not used bits
+ * 			02 - second return - RGL_RETURN_TYPE_LAST
+ *			01 - first return - RGL_RETURN_TYPE_STRONGEST
+ */
+const int32_t RGL_RETURN_MODE_BIT_SHIFT = 24;
+const int32_t RGL_RETURN_MODE_SINGLE = 1 << RGL_RETURN_MODE_BIT_SHIFT;
+const int32_t RGL_RETURN_MODE_DUAL = 2 << RGL_RETURN_MODE_BIT_SHIFT;
+const int32_t RGL_RETURN_TYPE_BIT_SHIFT = 8;
+
+/**
  * Kinds of return types for multi-return LiDAR output.
  */
 typedef enum : uint8_t
 {
-	RGL_RETURN_TYPE_UNKNOWN = 1 << 0,
-	RGL_RETURN_TYPE_STRONGEST = 1 << 1,
-	RGL_RETURN_TYPE_LAST = 1 << 2,
-	RGL_RETURN_TYPE_SECOND = 1 << 3,
-	RGL_RETURN_TYPE_FIRST = 1 << 4,
-	RGL_RETURN_TYPE_SECOND_STRONGEST = 1 << 5,
+	RGL_RETURN_TYPE_UNKNOWN = 0,
+	RGL_RETURN_TYPE_STRONGEST = 1,
+	RGL_RETURN_TYPE_LAST = 2,
+	RGL_RETURN_TYPE_SECOND = 3,
+	RGL_RETURN_TYPE_FIRST = 4,
+	RGL_RETURN_TYPE_SECOND_STRONGEST = 5,
 } rgl_return_type_t;
-
-/**
- * Bitshift and masks for coding return mode. Most significant byte encodes the number of returns.
- */
-const int32_t RGL_RETURN_MODE_RETURNS_BIT_SHIFT = 24;
-const int32_t RGL_RETURN_MODE_SINGLE_MASK = 1 << RGL_RETURN_MODE_RETURNS_BIT_SHIFT;
-const int32_t RGL_RETURN_MODE_DUAL_MASK = 2 << RGL_RETURN_MODE_RETURNS_BIT_SHIFT;
 
 /**
  * Kinds of return modes for multi-return LiDAR output.
  */
 typedef enum : int32_t
 {
-	RGL_RETURN_MODE_UNKNOWN = RGL_RETURN_TYPE_UNKNOWN,
+	RGL_RETURN_UNKNOWN = RGL_RETURN_TYPE_UNKNOWN,
 	// Single return modes
-	RGL_RETURN_FIRST = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_FIRST,
-	RGL_RETURN_SECOND = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_SECOND,
-	RGL_RETURN_LAST = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_LAST,
-	RGL_RETURN_STRONGEST = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_STRONGEST,
+	RGL_RETURN_FIRST = RGL_RETURN_MODE_SINGLE | RGL_RETURN_TYPE_FIRST,
+	RGL_RETURN_SECOND = RGL_RETURN_MODE_SINGLE | RGL_RETURN_TYPE_SECOND,
+	RGL_RETURN_LAST = RGL_RETURN_MODE_SINGLE | RGL_RETURN_TYPE_LAST,
+	RGL_RETURN_STRONGEST = RGL_RETURN_MODE_SINGLE | RGL_RETURN_TYPE_STRONGEST,
 	// Dual return modes
-	RGL_RETURN_LAST_STRONGEST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_LAST | RGL_RETURN_TYPE_STRONGEST,
-	RGL_RETURN_FIRST_LAST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_FIRST | RGL_RETURN_TYPE_LAST,
-	RGL_RETURN_FIRST_STRONGEST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_FIRST | RGL_RETURN_TYPE_STRONGEST,
-	RGL_RETURN_STRONGEST_SECOND_STRONGEST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_STRONGEST |
-	                                        RGL_RETURN_TYPE_SECOND_STRONGEST,
-	RGL_RETURN_FIRST_SECOND = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_FIRST | RGL_RETURN_TYPE_SECOND,
+	RGL_RETURN_LAST_STRONGEST = RGL_RETURN_MODE_DUAL | (RGL_RETURN_TYPE_LAST) |
+	                            (RGL_RETURN_TYPE_STRONGEST << RGL_RETURN_TYPE_BIT_SHIFT),
+	RGL_RETURN_FIRST_LAST = RGL_RETURN_MODE_DUAL | (RGL_RETURN_TYPE_FIRST) |
+	                        (RGL_RETURN_TYPE_LAST << RGL_RETURN_TYPE_BIT_SHIFT),
+	RGL_RETURN_FIRST_STRONGEST = RGL_RETURN_MODE_DUAL | (RGL_RETURN_TYPE_FIRST) |
+	                             (RGL_RETURN_TYPE_STRONGEST << RGL_RETURN_TYPE_BIT_SHIFT),
+	RGL_RETURN_STRONGEST_SECOND_STRONGEST = RGL_RETURN_MODE_DUAL | (RGL_RETURN_TYPE_STRONGEST) |
+	                                        (RGL_RETURN_TYPE_SECOND_STRONGEST << RGL_RETURN_TYPE_BIT_SHIFT),
+	RGL_RETURN_FIRST_SECOND = RGL_RETURN_MODE_DUAL | (RGL_RETURN_TYPE_FIRST) |
+	                          (RGL_RETURN_TYPE_SECOND << RGL_RETURN_TYPE_BIT_SHIFT),
 } rgl_return_mode_t;
 
 /**
@@ -876,7 +890,7 @@ RGL_API rgl_status_t rgl_node_points_compact_by_field(rgl_node_t* node, rgl_fiel
  * Creates or modifies SpatialMergePointsNode.
  * The Node merges point clouds spatially (e.g., multiple lidars outputs into one point cloud).
  * Only provided fields are merged (RGL_FIELD_DYNAMIC_FORMAT is not supported). This Node do not resolve point return types
- * (RGL_FIELD_RETURN_TYPE_U8) in any way - output return mode is always assumed to be RGL_RETURN_MODE_UNKNOWN and respective
+ * (RGL_FIELD_RETURN_TYPE_U8) in any way - output return mode is always assumed to be RGL_RETURN_UNKNOWN and respective
  * cloud points keep their return types. This may results in a case, where output point cloud contain points e.g. from
  * four or more return types (rgl_return_type_t).
  * Input point clouds must be unorganized (height == 1).
@@ -906,7 +920,7 @@ RGL_API rgl_status_t rgl_node_points_temporal_merge(rgl_node_t* node, const rgl_
 /**
  * Creates or modifies FromArrayPointsNode.
  * The Node provides initial points for its children Nodes. This Node does not handle return mode - it is assumed that
- * return mode is always RGL_RETURN_MODE_UNKNOWN. RGL_FIELD_RETURN_TYPE_U8 field values are still set according to data
+ * return mode is always RGL_RETURN_UNKNOWN. RGL_FIELD_RETURN_TYPE_U8 field values are still set according to data
  * passed by user.
  * Input: none
  * Output: point cloud

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -835,7 +835,7 @@ RGL_API rgl_status_t rgl_node_raytrace_configure_default_intensity(rgl_node_t no
  * RGL_RETURN_FIRST_LAST will result in point return types to be set to RGL_RETURN_TYPE_FIRST or RGL_RETURN_TYPE_LAST,
  * interchangeably.
  * Default return mode on RaytraceNode is RGL_RETURN_FIRST.
- * Passing RGL_RETURN_MODE_UNDEFINED will have no effect (does not change return mode).
+ * Passing RGL_RETURN_UNKNOWN is an invalid operation and will fail - user can not set RGL_RETURN_UNKNOWN as return mode.
  * @param node RaytraceNode to modify.
  * @param return_mode Return mode to set.
  */

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -423,14 +423,44 @@ typedef enum : int32_t
 } rgl_field_t;
 
 /**
- * Kinds of return type for multi-return LiDAR output.
+ * Kinds of return types for multi-return LiDAR output.
+ */
+typedef enum : uint8_t
+{
+	RGL_RETURN_TYPE_UNKNOWN = 1 << 0,
+	RGL_RETURN_TYPE_STRONGEST = 1 << 1,
+	RGL_RETURN_TYPE_LAST = 1 << 2,
+	RGL_RETURN_TYPE_SECOND = 1 << 3,
+	RGL_RETURN_TYPE_FIRST = 1 << 4,
+	RGL_RETURN_TYPE_SECOND_STRONGEST = 1 << 5,
+} rgl_return_type_t;
+
+/**
+ * Bitshift and masks for coding return mode. Most significant byte encodes the number of returns.
+ */
+const int32_t RGL_RETURN_MODE_RETURNS_BIT_SHIFT = 24;
+const int32_t RGL_RETURN_MODE_SINGLE_MASK = 1 << RGL_RETURN_MODE_RETURNS_BIT_SHIFT;
+const int32_t RGL_RETURN_MODE_DUAL_MASK = 2 << RGL_RETURN_MODE_RETURNS_BIT_SHIFT;
+
+/**
+ * Kinds of return modes for multi-return LiDAR output.
  */
 typedef enum : int32_t
 {
-	RGL_RETURN_TYPE_NOT_DIVERGENT = 0,
-	RGL_RETURN_TYPE_FIRST = 1,
-	RGL_RETURN_TYPE_LAST = 2,
-} rgl_return_type_t;
+	RGL_RETURN_MODE_UNKNOWN = RGL_RETURN_TYPE_UNKNOWN,
+	// Single return modes
+	RGL_RETURN_FIRST = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_FIRST,
+	RGL_RETURN_SECOND = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_SECOND,
+	RGL_RETURN_LAST = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_LAST,
+	RGL_RETURN_STRONGEST = RGL_RETURN_MODE_SINGLE_MASK | RGL_RETURN_TYPE_STRONGEST,
+	// Dual return modes
+	RGL_RETURN_LAST_STRONGEST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_LAST | RGL_RETURN_TYPE_STRONGEST,
+	RGL_RETURN_FIRST_LAST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_FIRST | RGL_RETURN_TYPE_LAST,
+	RGL_RETURN_FIRST_STRONGEST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_FIRST | RGL_RETURN_TYPE_STRONGEST,
+	RGL_RETURN_STRONGEST_SECOND_STRONGEST = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_STRONGEST |
+	                                        RGL_RETURN_TYPE_SECOND_STRONGEST,
+	RGL_RETURN_FIRST_SECOND = RGL_RETURN_MODE_DUAL_MASK | RGL_RETURN_TYPE_FIRST | RGL_RETURN_TYPE_SECOND,
+} rgl_return_mode_t;
 
 /**
  * Helper enum for axis selection
@@ -833,7 +863,10 @@ RGL_API rgl_status_t rgl_node_points_compact_by_field(rgl_node_t* node, rgl_fiel
 /**
  * Creates or modifies SpatialMergePointsNode.
  * The Node merges point clouds spatially (e.g., multiple lidars outputs into one point cloud).
- * Only provided fields are merged (RGL_FIELD_DYNAMIC_FORMAT is not supported).
+ * Only provided fields are merged (RGL_FIELD_DYNAMIC_FORMAT is not supported). This Node do not resolve point return types
+ * (RGL_FIELD_RETURN_TYPE_U8) in any way - output return mode is always assumed to be RGL_RETURN_MODE_UNKNOWN and respective
+ * cloud points keep their return types. This may results in a case, where output point cloud contain points e.g. from
+ * four or more return types (rgl_return_type_t).
  * Input point clouds must be unorganized (height == 1).
  * Any modification to the Node's parameters clears accumulated data.
  * Graph input: point cloud(s)
@@ -860,7 +893,9 @@ RGL_API rgl_status_t rgl_node_points_temporal_merge(rgl_node_t* node, const rgl_
 
 /**
  * Creates or modifies FromArrayPointsNode.
- * The Node provides initial points for its children Nodes.
+ * The Node provides initial points for its children Nodes. This Node does not handle return mode - it is assumed that
+ * return mode is always RGL_RETURN_MODE_UNKNOWN. RGL_FIELD_RETURN_TYPE_U8 field values are still set according to data
+ * passed by user.
  * Input: none
  * Output: point cloud
  * @param node If (*node) == nullptr, a new Node will be created. Otherwise, (*node) will be modified.

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1007,7 +1007,7 @@ RGL_API rgl_status_t rgl_node_raytrace_configure_return_mode(rgl_node_t node, rg
 	auto status = rglSafeCall([&]() {
 		RGL_API_LOG("rgl_node_raytrace_configure_default_intensity(node={}, return_mode={})", repr(node), return_mode);
 		CHECK_ARG(node != nullptr);
-
+		CHECK_ARG(return_mode != RGL_RETURN_UNKNOWN);
 		RaytraceNode::Ptr raytraceNode = Node::validatePtr<RaytraceNode>(node);
 		raytraceNode->setReturnMode(return_mode);
 	});

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1005,7 +1005,7 @@ void TapeCore::tape_node_raytrace_configure_default_intensity(const YAML::Node& 
 RGL_API rgl_status_t rgl_node_raytrace_configure_return_mode(rgl_node_t node, rgl_return_mode_t return_mode)
 {
 	auto status = rglSafeCall([&]() {
-		RGL_API_LOG("rgl_node_raytrace_configure_default_intensity(node={}, return_mode={})", repr(node), return_mode);
+		RGL_API_LOG("rgl_node_raytrace_configure_return_mode(node={}, return_mode={})", repr(node), return_mode);
 		CHECK_ARG(node != nullptr);
 		CHECK_ARG(return_mode != RGL_RETURN_UNKNOWN);
 		RaytraceNode::Ptr raytraceNode = Node::validatePtr<RaytraceNode>(node);
@@ -1021,7 +1021,6 @@ void TapeCore::tape_node_raytrace_configure_return_mode(const YAML::Node& yamlNo
 	auto returnMode = static_cast<rgl_return_mode_t>(yamlNode[1].as<int>());
 	rgl_node_t node = state.nodes.contains(nodeId) ? state.nodes.at(nodeId) : nullptr;
 	rgl_node_raytrace_configure_return_mode(node, returnMode);
-	state.nodes.insert({nodeId, node});
 }
 
 RGL_API rgl_status_t rgl_node_points_format(rgl_node_t* node, const rgl_field_t* fields, int32_t field_count)

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1400,27 +1400,6 @@ void TapeCore::tape_node_gaussian_noise_distance(const YAML::Node& yamlNode, Pla
 	state.nodes.insert({nodeId, node});
 }
 
-RGL_API rgl_status_t rgl_node_multi_return_switch(rgl_node_t* node, rgl_return_type_t return_type)
-{
-	auto status = rglSafeCall([&]() {
-		RGL_API_LOG("rgl_node_multi_return_switch(node={}, return_type={})", repr(node), return_type);
-		CHECK_ARG(node != nullptr);
-
-		createOrUpdateNode<MultiReturnSwitchNode>(node, return_type);
-	});
-	TAPE_HOOK(node, return_type);
-	return status;
-}
-
-void TapeCore::tape_node_multi_return_switch(const YAML::Node& yamlNode, PlaybackState& state)
-{
-	auto nodeId = yamlNode[0].as<TapeAPIObjectID>();
-	auto return_type = static_cast<rgl_return_type_t>(yamlNode[1].as<int>());
-	rgl_node_t node = state.nodes.contains(nodeId) ? state.nodes.at(nodeId) : nullptr;
-	rgl_node_multi_return_switch(&node, return_type);
-	state.nodes.insert({nodeId, node});
-}
-
 rgl_status_t rgl_node_is_alive(rgl_node_t node, bool* out_alive)
 {
 	auto status = rglSafeCall([&]() {

--- a/src/api/apiCore.cpp
+++ b/src/api/apiCore.cpp
@@ -1002,6 +1002,28 @@ void TapeCore::tape_node_raytrace_configure_default_intensity(const YAML::Node& 
 	rgl_node_raytrace_configure_default_intensity(node, yamlNode[1].as<float>());
 }
 
+RGL_API rgl_status_t rgl_node_raytrace_configure_return_mode(rgl_node_t node, rgl_return_mode_t return_mode)
+{
+	auto status = rglSafeCall([&]() {
+		RGL_API_LOG("rgl_node_raytrace_configure_default_intensity(node={}, return_mode={})", repr(node), return_mode);
+		CHECK_ARG(node != nullptr);
+
+		RaytraceNode::Ptr raytraceNode = Node::validatePtr<RaytraceNode>(node);
+		raytraceNode->setReturnMode(return_mode);
+	});
+	TAPE_HOOK(node, return_mode);
+	return status;
+}
+
+void TapeCore::tape_node_raytrace_configure_return_mode(const YAML::Node& yamlNode, PlaybackState& state)
+{
+	auto nodeId = yamlNode[0].as<TapeAPIObjectID>();
+	auto returnMode = static_cast<rgl_return_mode_t>(yamlNode[1].as<int>());
+	rgl_node_t node = state.nodes.contains(nodeId) ? state.nodes.at(nodeId) : nullptr;
+	rgl_node_raytrace_configure_return_mode(node, returnMode);
+	state.nodes.insert({nodeId, node});
+}
+
 RGL_API rgl_status_t rgl_node_points_format(rgl_node_t* node, const rgl_field_t* fields, int32_t field_count)
 {
 	auto status = rglSafeCall([&]() {

--- a/src/gpu/MultiReturn.hpp
+++ b/src/gpu/MultiReturn.hpp
@@ -26,3 +26,17 @@ struct MultiReturnPointers
 	Field<XYZ_VEC3_F32>::type* xyz;
 	Field<DISTANCE_F32>::type* distance;
 };
+
+struct MultiReturnSamplesPointers
+{
+	Field<IS_HIT_I32>::type* isHit;
+	Field<DISTANCE_F32>::type* distance;
+	Field<INTENSITY_F32>::type* intensity;
+	Field<LASER_RETRO_F32>::type* laserRetro;
+	Field<ENTITY_ID_I32>::type* entityId;
+	Field<ABSOLUTE_VELOCITY_VEC3_F32>::type* absVelocity;
+	Field<RELATIVE_VELOCITY_VEC3_F32>::type* relVelocity;
+	Field<RADIAL_SPEED_F32>::type* radialSpeed;
+	Field<NORMAL_VEC3_F32>::type* normal;
+	Field<INCIDENT_ANGLE_F32>::type* incidentAngle;
+};

--- a/src/gpu/MultiReturn.hpp
+++ b/src/gpu/MultiReturn.hpp
@@ -22,6 +22,8 @@
 
 struct MultiReturnSamplesPointers
 {
+	// XYZ is not stored for samples, because we calculate it alongside center ray direction. For this reason, only distance
+	// is necessary.
 	Field<IS_HIT_I32>::type* isHit;
 	Field<DISTANCE_F32>::type* distance;
 	Field<INTENSITY_F32>::type* intensity;

--- a/src/gpu/MultiReturn.hpp
+++ b/src/gpu/MultiReturn.hpp
@@ -20,13 +20,6 @@
 #define MULTI_RETURN_BEAM_LAYERS 3
 #define MULTI_RETURN_BEAM_SAMPLES (1 + (MULTI_RETURN_BEAM_VERTICES * MULTI_RETURN_BEAM_LAYERS))
 
-struct MultiReturnPointers
-{
-	Field<IS_HIT_I32>::type* isHit;
-	Field<XYZ_VEC3_F32>::type* xyz;
-	Field<DISTANCE_F32>::type* distance;
-};
-
 struct MultiReturnSamplesPointers
 {
 	Field<IS_HIT_I32>::type* isHit;

--- a/src/gpu/RaytraceRequestContext.hpp
+++ b/src/gpu/RaytraceRequestContext.hpp
@@ -54,6 +54,7 @@ struct RaytraceRequestContext
 	Field<IS_HIT_I32>::type* isHit;
 	Field<RAY_IDX_U32>::type* rayIdx;
 	Field<RING_ID_U16>::type* ringIdx;
+	Field<RETURN_TYPE_U8>::type* returnType;
 	Field<DISTANCE_F32>::type* distance;
 	Field<INTENSITY_F32>::type* intensityF32;
 	Field<INTENSITY_U8>::type* intensityU8;
@@ -70,8 +71,9 @@ struct RaytraceRequestContext
 	Field<INCIDENT_ANGLE_F32>::type* incidentAngle;
 
 	// Multi-Return
+	MultiReturnSamplesPointers mrSamples;
+	int returnCount;
 	float hBeamHalfDivergenceRad;
 	float vBeamHalfDivergenceRad;
-	MultiReturnPointers mrSamples;
 };
 static_assert(std::is_trivially_copyable<RaytraceRequestContext>::value);

--- a/src/gpu/nodeKernels.cu
+++ b/src/gpu/nodeKernels.cu
@@ -100,7 +100,8 @@ __device__ Vec3f reflectPolarization(const Vec3f& pol, const Vec3f& hitNormal, c
 	return -polCompR * refPolR + polCompU * refPolU;
 }
 
-__device__ void saveReturnHit(const RaytraceRequestContext* ctx, int beamIdx, int sampleIdx, int returnPointIdx, int returnType)
+__device__ void saveReturnAsHit(const RaytraceRequestContext* ctx, int beamIdx, int sampleIdx, int returnPointIdx,
+                                int returnType)
 {
 	if (ctx->xyz != nullptr) {
 		const Mat3x4f ray = ctx->raysWorld[beamIdx];
@@ -152,10 +153,12 @@ __device__ void saveReturnHit(const RaytraceRequestContext* ctx, int beamIdx, in
 	}
 }
 
-__device__ void saveReturnNonHit(const RaytraceRequestContext* ctx, int beamIdx, int returnPointIdx, int returnType)
+__device__ void saveReturnAsNonHit(const RaytraceRequestContext* ctx, int beamIdx, int returnPointIdx, int returnType)
 {
-	// Arbitrary decision - if all samples are non hit, I just take the distance from center ray. This distance will be either
-	// ctx.nearNonHitDistance or ctx.farNonHitDistance, based on optix kernel processing.
+	// Arbitrary decision - if all samples are non hits, I just take the distance from center ray. This distance will be either
+	// ctx.nearNonHitDistance or ctx.farNonHitDistance, based on optix kernel processing - check optixPrograms.cu. This provides
+	// being able to set below minRange, above maxRange and non hit results with the same code. Moreover, results for sample
+	// at idx 0 are always present with current implementation.
 	const auto nonHitDistance = ctx->mrSamples.distance[0];
 
 	if (ctx->xyz != nullptr) {
@@ -183,7 +186,6 @@ __device__ void saveReturnNonHit(const RaytraceRequestContext* ctx, int beamIdx,
 		ctx->intensityF32[returnPointIdx] = 0;
 	}
 	if (ctx->intensityU8 != nullptr) {
-		// intensity < 0 not possible
 		ctx->intensityU8[returnPointIdx] = 0;
 	}
 	if (ctx->entityId != nullptr) {
@@ -343,11 +345,7 @@ __global__ void kReduceDivergentBeams(size_t beamCount, int samplesPerBeam, rgl_
 	int strongest = -1, secondStrongest = -1;
 	int sampleIdx = firstSampleInBeamIdx;
 
-//	printf("firstSampleIdx: %d samplesPerBeam: %d\n", firstSampleInBeamIdx, samplesPerBeam);
-
 	for (; sampleIdx < firstSampleInBeamIdx + samplesPerBeam; ++sampleIdx) {
-		//		printf("sample after optix %f %f %f\n", ctx->mrSamples.xyz[sampleIdx].x(), ctx->mrSamples.xyz[sampleIdx].y(),
-		//		       ctx->mrSamples.xyz[sampleIdx].z());
 		if (ctx->mrSamples.isHit[sampleIdx] == 1) {
 			first = sampleIdx;
 			second = first;
@@ -359,19 +357,16 @@ __global__ void kReduceDivergentBeams(size_t beamCount, int samplesPerBeam, rgl_
 	}
 
 	const auto returnCount = returnMode >> RGL_RETURN_MODE_BIT_SHIFT;
-	//printf("returnMode: %d returnCount: %d\n", returnMode, returnCount);
 
 	// There were no hits within beam samples.
 	if (first == -1) {
 		for (int returnIdx = 0; returnIdx < returnCount; ++returnIdx) {
 			const auto returnPointIdx = beamIdx * returnCount + returnIdx;
 			const auto returnType = (returnMode >> (returnIdx * RGL_RETURN_TYPE_BIT_SHIFT)) & 0xff;
-			saveReturnNonHit(ctx, beamIdx, returnPointIdx, returnType);
+			saveReturnAsNonHit(ctx, beamIdx, returnPointIdx, returnType);
 		}
 		return;
 	}
-
-	//printf("reference sample idx: %d\n", sampleIdx);
 
 	// Base initial values on first sample that returned a hit.
 	for (sampleIdx = sampleIdx + 1; sampleIdx < firstSampleInBeamIdx + samplesPerBeam; ++sampleIdx) {
@@ -379,7 +374,6 @@ __global__ void kReduceDivergentBeams(size_t beamCount, int samplesPerBeam, rgl_
 			continue;
 		}
 
-		// TODO(Pawel): Revise this logic.
 		const auto currentSampleDistance = ctx->mrSamples.distance[sampleIdx];
 		if (currentSampleDistance < ctx->mrSamples.distance[first]) {
 			// Sample is closer than first. I ignore current == first, because then second would become equal to first.
@@ -406,35 +400,25 @@ __global__ void kReduceDivergentBeams(size_t beamCount, int samplesPerBeam, rgl_
 		}
 	}
 
-//		printf("first: %d, second: %d, last: %d, strongest: %d, secondStrongest: %d\n", first, second, last, strongest,
-//		       secondStrongest);
-
 	for (int returnIdx = 0; returnIdx < returnCount; ++returnIdx) {
 		const auto returnType = (returnMode >> (returnIdx * RGL_RETURN_TYPE_BIT_SHIFT)) & 0xff;
-		int rayIdx = -1;
-
-//		printf("return idx: %d test: %d return types: %d\n", returnIdx, (returnMode >> (returnIdx * RGL_RETURN_TYPE_BIT_SHIFT)) & 0xff, returnType);
+		sampleIdx = -1;
 
 		if (returnType == RGL_RETURN_TYPE_FIRST) {
-			rayIdx = first;
+			sampleIdx = first;
 		} else if (returnType == RGL_RETURN_TYPE_SECOND) {
-			rayIdx = second;
+			sampleIdx = second;
 		} else if (returnType == RGL_RETURN_TYPE_LAST) {
-			rayIdx = last;
+			sampleIdx = last;
 		} else if (returnType == RGL_RETURN_TYPE_STRONGEST) {
-			rayIdx = strongest;
+			sampleIdx = strongest;
 		} else if (returnType == RGL_RETURN_TYPE_SECOND_STRONGEST) {
-			rayIdx = secondStrongest;
+			sampleIdx = secondStrongest;
 		}
 
-		if (rayIdx >= 0) {
+		if (sampleIdx >= 0) {
 			const auto returnPointIdx = beamIdx * returnCount + returnIdx;
-//			printf("assigned sample: %f %f %f\n", ctx->mrSamples.xyz[rayIdx].x(), ctx->mrSamples.xyz[rayIdx].y(),
-//			       ctx->mrSamples.xyz[rayIdx].z());
-			saveReturnHit(ctx, beamIdx, rayIdx, returnPointIdx, returnType);
-			//			printf("assigned xyz: %f %f %f\n", ctx->xyz[returnPointIdx].x(), ctx->xyz[returnPointIdx].y(),
-			//			       ctx->xyz[returnPointIdx].z());
-			//printf("%f %f %f\n", ctx->mrSamples.xyz[sampleIdx].x(), ctx->mrSamples.xyz[sampleIdx].y(), ctx->mrSamples.xyz[sampleIdx].z());
+			saveReturnAsHit(ctx, beamIdx, sampleIdx, returnPointIdx, returnType);
 		}
 	}
 }

--- a/src/gpu/nodeKernels.cu
+++ b/src/gpu/nodeKernels.cu
@@ -416,6 +416,8 @@ __global__ void kReduceDivergentBeams(size_t beamCount, int samplesPerBeam, rgl_
 			sampleIdx = secondStrongest;
 		}
 
+		// TODO(Pawel): Consider saveReturnAsNonHit on failing this checkout. However, -1 on sampleIdx is a process issue here.
+		// More useful solution would be a way to verify returnMode somewhere before even calling kernels.
 		if (sampleIdx >= 0) {
 			const auto returnPointIdx = beamIdx * returnCount + returnIdx;
 			saveReturnAsHit(ctx, beamIdx, sampleIdx, returnPointIdx, returnType);

--- a/src/gpu/nodeKernels.hpp
+++ b/src/gpu/nodeKernels.hpp
@@ -53,7 +53,5 @@ void gpuRadarComputeEnergy(cudaStream_t stream, size_t count, float rayAzimuthSt
                            Mat3x4f lookAtOriginTransform, const Field<RAY_POSE_MAT3x4_F32>::type* rayPose,
                            const Field<DISTANCE_F32>::type* hitDist, const Field<NORMAL_VEC3_F32>::type* hitNorm,
                            const Field<XYZ_VEC3_F32>::type* hitPos, Vector<3, thrust::complex<float>>* outBUBRFactor);
-void gpuProcessBeamSamplesFirstLast(cudaStream_t stream, size_t beamCount, int samplesPerBeam, MultiReturnPointers beamSamples,
-                                    MultiReturnPointers first, MultiReturnPointers last, const Mat3x4f* beamWorld);
 void gpuReduceDivergentBeams(cudaStream_t stream, size_t beamCount, int samplesPerBeam, rgl_return_mode_t returnMode,
                              const RaytraceRequestContext* ctx);

--- a/src/gpu/nodeKernels.hpp
+++ b/src/gpu/nodeKernels.hpp
@@ -23,6 +23,7 @@
 #include <RGLFields.hpp>
 #include <thrust/complex.h>
 #include <gpu/MultiReturn.hpp>
+#include <gpu/RaytraceRequestContext.hpp>
 
 /*
  * The following functions are asynchronous!
@@ -54,3 +55,5 @@ void gpuRadarComputeEnergy(cudaStream_t stream, size_t count, float rayAzimuthSt
                            const Field<XYZ_VEC3_F32>::type* hitPos, Vector<3, thrust::complex<float>>* outBUBRFactor);
 void gpuProcessBeamSamplesFirstLast(cudaStream_t stream, size_t beamCount, int samplesPerBeam, MultiReturnPointers beamSamples,
                                     MultiReturnPointers first, MultiReturnPointers last, const Mat3x4f* beamWorld);
+void gpuReduceDivergentBeams(cudaStream_t stream, size_t beamCount, int samplesPerBeam, rgl_return_mode_t returnMode,
+                             const RaytraceRequestContext* ctx);

--- a/src/gpu/optixPrograms.cu
+++ b/src/gpu/optixPrograms.cu
@@ -336,7 +336,7 @@ __device__ void saveNonHitBeamSamples(int beamIdx, float nonHitDistance)
 
 __device__ void saveBeamSharedData(int beamIdx, const Mat3x4f& rayLocal)
 {
-	for (int returnPointIdx = beamIdx; returnPointIdx < beamIdx + ctx.returnCount; ++returnPointIdx) {
+	for (int returnPointIdx = beamIdx * ctx.returnCount; returnPointIdx < (beamIdx + 1) * ctx.returnCount; ++returnPointIdx) {
 		if (ctx.rayIdx != nullptr) {
 			ctx.rayIdx[returnPointIdx] = beamIdx;
 		}

--- a/src/gpu/optixPrograms.cu
+++ b/src/gpu/optixPrograms.cu
@@ -329,7 +329,7 @@ __device__ void saveSampleAsHit(int sampleIdx, float distance, float intensity, 
 
 __device__ void saveNonHitBeamSamples(int beamIdx, float nonHitDistance)
 {
-	for (int sampleIdx = beamIdx; sampleIdx < beamIdx + MULTI_RETURN_BEAM_SAMPLES; ++sampleIdx) {
+	for (int sampleIdx = beamIdx * MULTI_RETURN_BEAM_SAMPLES; sampleIdx < beamIdx * MULTI_RETURN_BEAM_SAMPLES + MULTI_RETURN_BEAM_SAMPLES; ++sampleIdx) {
 		saveSampleAsNonHit(sampleIdx, nonHitDistance);
 	}
 }

--- a/src/gpu/optixPrograms.cu
+++ b/src/gpu/optixPrograms.cu
@@ -33,54 +33,33 @@ static constexpr float toDeg = (180.0f / M_PI);
 extern "C" static __constant__ RaytraceRequestContext ctx;
 
 // Helper functions
-template<bool isFinite>
-__device__ void saveRayResult(const Vec3f& xyz, float distance, float intensity, int objectID, const Vec3f& absVelocity,
-                              const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal, float incidentAngle,
-                              float laserRetro);
-__device__ void saveNonHitRayResult(float nonHitDistance);
+//template<bool isFinite>
+//__device__ void saveRayResult(const Vec3f& xyz, float distance, float intensity, int objectID, const Vec3f& absVelocity,
+//                              const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal, float incidentAngle,
+//                              float laserRetro);
+//__device__ void saveNonHitRayResult(float nonHitDistance);
+__device__ void saveSampleAsNonHit(int sampleIdx, float nonHitDistance);
+__device__ void saveSampleAsHit(int sampleIdx, float distance, float intensity, float laserRetro, int objectID,
+                                const Vec3f& absVelocity, const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal,
+                                float incidentAngle);
+__device__ void saveNonHitBeamSamples(int beamIdx, float nonHitDistance);
+__device__ void saveBeamSharedData(int beamIdx, const Mat3x4f& rayLocal);
 __device__ void shootSamplingRay(const Mat3x4f& ray, float maxRange, unsigned sampleBeamIdx);
 __device__ Mat3x4f makeBeamSampleRayTransform(float hHalfDivergenceRad, float vHalfDivergenceRad, unsigned layerIdx,
                                               unsigned vertexIdx);
 
 extern "C" __global__ void __raygen__()
 {
-	if (ctx.scene == 0) {
-		saveNonHitRayResult(
-		    ctx.farNonHitDistance); // TODO(prybicki): Remove this, assume that host code will not pass invalid scene.
-		return;
-	}
-
 	const int rayIdx = static_cast<int>(optixGetLaunchIndex().x);
-
-	if (ctx.rayMask != nullptr && ctx.rayMask[rayIdx] == 0) {
-		saveNonHitRayResult(ctx.farNonHitDistance);
-		return;
-	}
-
 	Mat3x4f ray = ctx.raysWorld[rayIdx];
 	const Mat3x4f rayLocal =
 	    ctx.rayOriginToWorld.inverse() *
 	    ray; // TODO(prybicki): instead of computing inverse, we should pass rays in local CF and then transform them to world CF.
 
-	// Assuming up vector is Y, forward vector is Z (true for Unity).
-	// TODO(msz-rai): allow to define up and forward vectors in RGL
-	// Assuming rays are generated in left-handed coordinate system with the rotation applied in ZXY order.
-	// TODO(msz-rai): move ray generation to RGL to unify rotations
-	if (ctx.azimuth != nullptr) {
-		ctx.azimuth[rayIdx] = rayLocal.toRotationYOrderZXYLeftHandRad();
-	}
-	if (ctx.elevation != nullptr) {
-		ctx.elevation[rayIdx] = rayLocal.toRotationXOrderZXYLeftHandRad();
-	}
-
-	if (ctx.timestampF64 != nullptr) {
-		ctx.timestampF64[rayIdx] = ctx.doApplyDistortion ? ctx.rayTimeOffsetsMs[rayIdx] * 1e-3f : 0; // in seconds
-	}
-	if (ctx.timestampU32 != nullptr) {
-		ctx.timestampU32[rayIdx] = ctx.doApplyDistortion ?
-		                               static_cast<uint32_t>(ctx.rayTimeOffsetsMs[rayIdx] * 1e6f) // in nanoseconds
-		                               :
-		                               0;
+	saveBeamSharedData(rayIdx, rayLocal);
+	if (ctx.rayMask != nullptr && ctx.rayMask[rayIdx] == 0) {
+		saveNonHitBeamSamples(rayIdx, ctx.farNonHitDistance);
+		return;
 	}
 
 	if (ctx.doApplyDistortion) {
@@ -115,10 +94,11 @@ extern "C" __global__ void __miss__()
 {
 	const int beamIdx = static_cast<int>(optixGetLaunchIndex().x);
 	const int beamSampleIdx = static_cast<int>(optixGetPayload_0());
-	ctx.mrSamples.isHit[beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleIdx] = false;
-	if (beamSampleIdx == 0) {
-		saveNonHitRayResult(ctx.farNonHitDistance);
-	}
+	//	ctx.mrSamples.isHit[beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleIdx] = false;
+	//	if (beamSampleIdx == 0) {
+	//		saveNonHitRayResult(ctx.farNonHitDistance);
+	//	}
+	saveSampleAsNonHit(beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleIdx, ctx.farNonHitDistance);
 }
 
 extern "C" __global__ void __closesthit__()
@@ -143,7 +123,7 @@ extern "C" __global__ void __closesthit__()
 	const unsigned beamSampleRayIdx = optixGetPayload_0();
 	const unsigned circleIdx = (beamSampleRayIdx - 1) / MULTI_RETURN_BEAM_VERTICES;
 	const unsigned vertexIdx = (beamSampleRayIdx - 1) % MULTI_RETURN_BEAM_VERTICES;
-	const unsigned mrSamplesIdx = beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleRayIdx;
+	const unsigned mrSampleIdx = beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleRayIdx;
 	const Vec3f beamSampleOrigin = optixGetWorldRayOrigin();
 	const int entityId = static_cast<int>(optixGetInstanceId());
 	const float laserRetro = entityData.laserRetro;
@@ -171,11 +151,13 @@ extern "C" __global__ void __closesthit__()
 	// Early out for points that are too close to the sensor
 	float minRange = ctx.rayRangesCount == 1 ? ctx.rayRanges[0].x() : ctx.rayRanges[optixGetLaunchIndex().x].x();
 	if (distance < minRange) {
-		ctx.mrSamples.isHit[mrSamplesIdx] = false;
-		if (beamSampleRayIdx == 0) {
-			saveNonHitRayResult(ctx.nearNonHitDistance);
-		}
+		saveSampleAsNonHit(mrSampleIdx, ctx.nearNonHitDistance);
 		return;
+		//		ctx.mrSamples.isHit[mrSamplesIdx] = false;
+		//		if (beamSampleRayIdx == 0) {
+		//			saveNonHitRayResult(ctx.nearNonHitDistance);
+		//		}
+		//		return;
 	}
 
 	// Normal vector
@@ -208,12 +190,16 @@ extern "C" __global__ void __closesthit__()
 	}
 	intensity *= cosIncidentAngle;
 
+	//	ctx.samplesIsHit[mrSamplesIdx] = true;
+	//	ctx.samplesDistance[mrSamplesIdx] = static_cast<float>(distance);
+	//	ctx.samplesIntensity[mrSamplesIdx] = intensity;
+
 	// Save sub-sampling results
-	ctx.mrSamples.isHit[mrSamplesIdx] = true;
-	ctx.mrSamples.distance[mrSamplesIdx] = distance;
-	if (beamSampleRayIdx != 0) {
-		return;
-	}
+	//	ctx.mrSamples.isHit[mrSamplesIdx] = true;
+	//	ctx.mrSamples.distance[mrSamplesIdx] = distance;
+	//	if (beamSampleRayIdx != 0) {
+	//		return;
+	//	}
 
 	Vec3f absPointVelocity{NAN};
 	Vec3f relPointVelocity{NAN};
@@ -260,8 +246,16 @@ extern "C" __global__ void __closesthit__()
 
 		radialSpeed = hitRays.normalized().dot(relPointVelocity);
 	}
-	saveRayResult<true>(hitWorldSeenBySensor, distance, intensity, entityId, absPointVelocity, relPointVelocity, radialSpeed,
-	                    wNormal, incidentAngle, laserRetro);
+
+	saveSampleAsHit(mrSampleIdx, distance, intensity, laserRetro, entityId, absPointVelocity, relPointVelocity, radialSpeed,
+	                wNormal, incidentAngle);
+
+	//	printf("sample idx: %d distance: %f xyz: %f %f %f mr samples xyz: %f %f %f\n", mrSampleIdx, distance,
+	//	       hitWorldSeenBySensor.x(), hitWorldSeenBySensor.y(), hitWorldSeenBySensor.z(), ctx.mrSamples.xyz[mrSampleIdx].x(),
+	//	       ctx.mrSamples.xyz[mrSampleIdx].y(), ctx.mrSamples.xyz[mrSampleIdx].z());
+
+	//	saveRayResult<true>(hitWorldSeenBySensor, distance, intensity, entityId, absPointVelocity, relPointVelocity, radialSpeed,
+	//	                    wNormal, incidentAngle, laserRetro);
 }
 
 extern "C" __global__ void __anyhit__() {}
@@ -296,66 +290,140 @@ __device__ Mat3x4f makeBeamSampleRayTransform(float hHalfDivergenceRad, float vH
 	return Mat3x4f::rotationRad(vAngle, 0.0f, 0.0f) * Mat3x4f::rotationRad(0.0f, hAngle, 0.0f);
 }
 
-__device__ void saveNonHitRayResult(float nonHitDistance)
+__device__ void saveSampleAsNonHit(int sampleIdx, float nonHitDistance)
 {
-	Mat3x4f ray = ctx.raysWorld[optixGetLaunchIndex().x];
-	Vec3f origin = ray * Vec3f{0, 0, 0};
-	Vec3f dir = ray * Vec3f{0, 0, 1} - origin;
-	Vec3f displacement = dir.normalized() * nonHitDistance;
-	displacement = {isnan(displacement.x()) ? 0 : displacement.x(), isnan(displacement.y()) ? 0 : displacement.y(),
-	                isnan(displacement.z()) ? 0 : displacement.z()};
-	Vec3f xyz = origin + displacement;
-	saveRayResult<false>(xyz, nonHitDistance, 0, RGL_ENTITY_INVALID_ID, Vec3f{NAN}, Vec3f{NAN}, 0.0f, Vec3f{NAN}, NAN, 0.0f);
+	ctx.mrSamples.isHit[sampleIdx] = false;
+	ctx.mrSamples.distance[sampleIdx] = nonHitDistance;
 }
 
-template<bool isFinite>
-__device__ void saveRayResult(const Vec3f& xyz, float distance, float intensity, const int objectID, const Vec3f& absVelocity,
-                              const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal, float incidentAngle,
-                              float laserRetro)
+__device__ void saveSampleAsHit(int sampleIdx, float distance, float intensity, float laserRetro, int objectID,
+                                const Vec3f& absVelocity, const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal,
+                                float incidentAngle)
 {
-	const int beamIdx = static_cast<int>(optixGetLaunchIndex().x);
-	if (ctx.xyz != nullptr) {
-		// Return actual XYZ of the hit point or infinity vector.
-		ctx.xyz[beamIdx] = xyz;
+	ctx.mrSamples.isHit[sampleIdx] = true;
+	ctx.mrSamples.distance[sampleIdx] = distance;
+	ctx.mrSamples.intensity[sampleIdx] = intensity;
+
+	if (ctx.mrSamples.laserRetro != nullptr) {
+		ctx.mrSamples.laserRetro[sampleIdx] = laserRetro;
 	}
-	if (ctx.isHit != nullptr) {
-		ctx.isHit[beamIdx] = isFinite;
+	if (ctx.mrSamples.entityId != nullptr) {
+		ctx.mrSamples.entityId[sampleIdx] = objectID;
 	}
-	if (ctx.rayIdx != nullptr) {
-		ctx.rayIdx[beamIdx] = beamIdx;
+	if (ctx.mrSamples.absVelocity != nullptr) {
+		ctx.mrSamples.absVelocity[sampleIdx] = absVelocity;
 	}
-	if (ctx.ringIdx != nullptr && ctx.ringIds != nullptr) {
-		ctx.ringIdx[beamIdx] = ctx.ringIds[beamIdx % ctx.ringIdsCount];
+	if (ctx.mrSamples.relVelocity != nullptr) {
+		ctx.mrSamples.relVelocity[sampleIdx] = relVelocity;
 	}
-	if (ctx.distance != nullptr) {
-		ctx.distance[beamIdx] = distance;
+	if (ctx.mrSamples.radialSpeed != nullptr) {
+		ctx.mrSamples.radialSpeed[sampleIdx] = radialSpeed;
 	}
-	if (ctx.intensityF32 != nullptr) {
-		ctx.intensityF32[beamIdx] = intensity;
+	if (ctx.mrSamples.normal != nullptr) {
+		ctx.mrSamples.normal[sampleIdx] = normal;
 	}
-	if (ctx.intensityU8 != nullptr) {
-		// intensity < 0 not possible
-		ctx.intensityU8[beamIdx] = intensity < UINT8_MAX ? static_cast<uint8_t>(std::round(intensity)) : UINT8_MAX;
-	}
-	if (ctx.entityId != nullptr) {
-		ctx.entityId[beamIdx] = isFinite ? objectID : RGL_ENTITY_INVALID_ID;
-	}
-	if (ctx.pointAbsVelocity != nullptr) {
-		ctx.pointAbsVelocity[beamIdx] = absVelocity;
-	}
-	if (ctx.pointRelVelocity != nullptr) {
-		ctx.pointRelVelocity[beamIdx] = relVelocity;
-	}
-	if (ctx.radialSpeed != nullptr) {
-		ctx.radialSpeed[beamIdx] = radialSpeed;
-	}
-	if (ctx.normal != nullptr) {
-		ctx.normal[beamIdx] = normal;
-	}
-	if (ctx.incidentAngle != nullptr) {
-		ctx.incidentAngle[beamIdx] = incidentAngle;
-	}
-	if (ctx.laserRetro != nullptr) {
-		ctx.laserRetro[beamIdx] = laserRetro;
+	if (ctx.mrSamples.incidentAngle != nullptr) {
+		ctx.mrSamples.incidentAngle[sampleIdx] = incidentAngle;
 	}
 }
+
+__device__ void saveNonHitBeamSamples(int beamIdx, float nonHitDistance)
+{
+	for (int sampleIdx = beamIdx; sampleIdx < beamIdx + MULTI_RETURN_BEAM_SAMPLES; ++sampleIdx) {
+		saveSampleAsNonHit(sampleIdx, nonHitDistance);
+	}
+}
+
+__device__ void saveBeamSharedData(int beamIdx, const Mat3x4f& rayLocal)
+{
+	for (int returnPointIdx = beamIdx; returnPointIdx < beamIdx + ctx.returnCount; ++returnPointIdx) {
+		if (ctx.rayIdx != nullptr) {
+			ctx.rayIdx[returnPointIdx] = beamIdx;
+		}
+
+		// Assuming up vector is Y, forward vector is Z (true for Unity).
+		// TODO(msz-rai): allow to define up and forward vectors in RGL
+		// Assuming rays are generated in left-handed coordinate system with the rotation applied in ZXY order.
+		// TODO(msz-rai): move ray generation to RGL to unify rotations
+		if (ctx.azimuth != nullptr) {
+			ctx.azimuth[returnPointIdx] = rayLocal.toRotationYOrderZXYLeftHandRad();
+		}
+		if (ctx.elevation != nullptr) {
+			ctx.elevation[returnPointIdx] = rayLocal.toRotationXOrderZXYLeftHandRad();
+		}
+
+		if (ctx.timestampF64 != nullptr) {
+			ctx.timestampF64[returnPointIdx] = ctx.doApplyDistortion ? ctx.rayTimeOffsetsMs[beamIdx] * 1e-3f : 0; // in seconds
+		}
+		if (ctx.timestampU32 != nullptr) {
+			ctx.timestampU32[returnPointIdx] = ctx.doApplyDistortion ?
+			                                       static_cast<uint32_t>(ctx.rayTimeOffsetsMs[beamIdx] * 1e6f) // in nanoseconds
+			                                       :
+			                                       0;
+		}
+	}
+}
+
+//__device__ void saveNonHitRayResult(float nonHitDistance)
+//{
+//	Mat3x4f ray = ctx.raysWorld[optixGetLaunchIndex().x];
+//	Vec3f origin = ray * Vec3f{0, 0, 0};
+//	Vec3f dir = ray * Vec3f{0, 0, 1} - origin;
+//	Vec3f displacement = dir.normalized() * nonHitDistance;
+//	displacement = {isnan(displacement.x()) ? 0 : displacement.x(), isnan(displacement.y()) ? 0 : displacement.y(),
+//	                isnan(displacement.z()) ? 0 : displacement.z()};
+//	Vec3f xyz = origin + displacement;
+//	saveRayResult<false>(xyz, nonHitDistance, 0, RGL_ENTITY_INVALID_ID, Vec3f{NAN}, Vec3f{NAN}, 0.0f, Vec3f{NAN}, NAN, 0.0f);
+//}
+
+//template<bool isFinite>
+//__device__ void saveRayResult(const Vec3f& xyz, float distance, float intensity, const int objectID, const Vec3f& absVelocity,
+//                              const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal, float incidentAngle,
+//                              float laserRetro)
+//{
+//	const int beamIdx = static_cast<int>(optixGetLaunchIndex().x);
+//	if (ctx.xyz != nullptr) {
+//		// Return actual XYZ of the hit point or infinity vector.
+//		ctx.xyz[beamIdx] = xyz;
+//	}
+//	if (ctx.isHit != nullptr) {
+//		ctx.isHit[beamIdx] = isFinite;
+//	}
+//	if (ctx.rayIdx != nullptr) {
+//		ctx.rayIdx[beamIdx] = beamIdx;
+//	}
+//	if (ctx.ringIdx != nullptr && ctx.ringIds != nullptr) {
+//		ctx.ringIdx[beamIdx] = ctx.ringIds[beamIdx % ctx.ringIdsCount];
+//	}
+//	if (ctx.distance != nullptr) {
+//		ctx.distance[beamIdx] = distance;
+//	}
+//	if (ctx.intensityF32 != nullptr) {
+//		ctx.intensityF32[beamIdx] = intensity;
+//	}
+//	if (ctx.intensityU8 != nullptr) {
+//		// intensity < 0 not possible
+//		ctx.intensityU8[beamIdx] = intensity < UINT8_MAX ? static_cast<uint8_t>(std::round(intensity)) : UINT8_MAX;
+//	}
+//	if (ctx.entityId != nullptr) {
+//		ctx.entityId[beamIdx] = isFinite ? objectID : RGL_ENTITY_INVALID_ID;
+//	}
+//	if (ctx.pointAbsVelocity != nullptr) {
+//		ctx.pointAbsVelocity[beamIdx] = absVelocity;
+//	}
+//	if (ctx.pointRelVelocity != nullptr) {
+//		ctx.pointRelVelocity[beamIdx] = relVelocity;
+//	}
+//	if (ctx.radialSpeed != nullptr) {
+//		ctx.radialSpeed[beamIdx] = radialSpeed;
+//	}
+//	if (ctx.normal != nullptr) {
+//		ctx.normal[beamIdx] = normal;
+//	}
+//	if (ctx.incidentAngle != nullptr) {
+//		ctx.incidentAngle[beamIdx] = incidentAngle;
+//	}
+//	if (ctx.laserRetro != nullptr) {
+//		ctx.laserRetro[beamIdx] = laserRetro;
+//	}
+//}

--- a/src/gpu/optixPrograms.cu
+++ b/src/gpu/optixPrograms.cu
@@ -33,11 +33,6 @@ static constexpr float toDeg = (180.0f / M_PI);
 extern "C" static __constant__ RaytraceRequestContext ctx;
 
 // Helper functions
-//template<bool isFinite>
-//__device__ void saveRayResult(const Vec3f& xyz, float distance, float intensity, int objectID, const Vec3f& absVelocity,
-//                              const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal, float incidentAngle,
-//                              float laserRetro);
-//__device__ void saveNonHitRayResult(float nonHitDistance);
 __device__ void saveSampleAsNonHit(int sampleIdx, float nonHitDistance);
 __device__ void saveSampleAsHit(int sampleIdx, float distance, float intensity, float laserRetro, int objectID,
                                 const Vec3f& absVelocity, const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal,
@@ -56,6 +51,7 @@ extern "C" __global__ void __raygen__()
 	    ctx.rayOriginToWorld.inverse() *
 	    ray; // TODO(prybicki): instead of computing inverse, we should pass rays in local CF and then transform them to world CF.
 
+	// Saving data for non-hit samples is necessary here - otherwise this data will not be initialized.
 	saveNonHitBeamSamples(rayIdx, ctx.farNonHitDistance);
 	saveBeamSharedData(rayIdx, rayLocal);
 	if (ctx.rayMask != nullptr && ctx.rayMask[rayIdx] == 0) {
@@ -94,10 +90,6 @@ extern "C" __global__ void __miss__()
 {
 	const int beamIdx = static_cast<int>(optixGetLaunchIndex().x);
 	const int beamSampleIdx = static_cast<int>(optixGetPayload_0());
-	//	ctx.mrSamples.isHit[beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleIdx] = false;
-	//	if (beamSampleIdx == 0) {
-	//		saveNonHitRayResult(ctx.farNonHitDistance);
-	//	}
 	saveSampleAsNonHit(beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleIdx, ctx.farNonHitDistance);
 }
 
@@ -120,10 +112,8 @@ extern "C" __global__ void __closesthit__()
 
 	// Ray
 	const int beamIdx = static_cast<int>(optixGetLaunchIndex().x);
-	const unsigned beamSampleRayIdx = optixGetPayload_0();
-	const unsigned circleIdx = (beamSampleRayIdx - 1) / MULTI_RETURN_BEAM_VERTICES;
-	const unsigned vertexIdx = (beamSampleRayIdx - 1) % MULTI_RETURN_BEAM_VERTICES;
-	const unsigned mrSampleIdx = beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleRayIdx;
+	const int beamSampleRayIdx = static_cast<int>(optixGetPayload_0());
+	const int mrSampleIdx = beamIdx * MULTI_RETURN_BEAM_SAMPLES + beamSampleRayIdx;
 	const Vec3f beamSampleOrigin = optixGetWorldRayOrigin();
 	const int entityId = static_cast<int>(optixGetInstanceId());
 	const float laserRetro = entityData.laserRetro;
@@ -134,30 +124,12 @@ extern "C" __global__ void __closesthit__()
 	const Vector<3, double> hwrd = hitWorldRaytraced;
 	const Vector<3, double> hso = beamSampleOrigin;
 	const double distance = (hwrd - hso).length();
-	const Vec3f hitWorldSeenBySensor = [&]() {
-		if (!ctx.doApplyDistortion) {
-			return hitWorldRaytraced;
-		}
-		Mat3x4f sampleRayTf = beamSampleRayIdx == 0 ?
-		                          Mat3x4f::identity() :
-		                          makeBeamSampleRayTransform(ctx.hBeamHalfDivergenceRad, ctx.vBeamHalfDivergenceRad, circleIdx,
-		                                                     vertexIdx);
-		Mat3x4f undistortedRay = ctx.raysWorld[beamIdx] * sampleRayTf;
-		Vec3f undistortedOrigin = undistortedRay * Vec3f{0, 0, 0};
-		Vec3f undistortedDir = undistortedRay * Vec3f{0, 0, 1} - undistortedOrigin;
-		return undistortedOrigin + undistortedDir * distance;
-	}();
 
 	// Early out for points that are too close to the sensor
 	float minRange = ctx.rayRangesCount == 1 ? ctx.rayRanges[0].x() : ctx.rayRanges[optixGetLaunchIndex().x].x();
 	if (distance < minRange) {
 		saveSampleAsNonHit(mrSampleIdx, ctx.nearNonHitDistance);
 		return;
-		//		ctx.mrSamples.isHit[mrSamplesIdx] = false;
-		//		if (beamSampleRayIdx == 0) {
-		//			saveNonHitRayResult(ctx.nearNonHitDistance);
-		//		}
-		//		return;
 	}
 
 	// Normal vector
@@ -189,17 +161,6 @@ extern "C" __global__ void __closesthit__()
 		intensity = tex2D<TextureTexelFormat>(entityData.texture, uv[0], uv[1]);
 	}
 	intensity *= cosIncidentAngle;
-
-	//	ctx.samplesIsHit[mrSamplesIdx] = true;
-	//	ctx.samplesDistance[mrSamplesIdx] = static_cast<float>(distance);
-	//	ctx.samplesIntensity[mrSamplesIdx] = intensity;
-
-	// Save sub-sampling results
-	//	ctx.mrSamples.isHit[mrSamplesIdx] = true;
-	//	ctx.mrSamples.distance[mrSamplesIdx] = distance;
-	//	if (beamSampleRayIdx != 0) {
-	//		return;
-	//	}
 
 	Vec3f absPointVelocity{NAN};
 	Vec3f relPointVelocity{NAN};
@@ -249,13 +210,6 @@ extern "C" __global__ void __closesthit__()
 
 	saveSampleAsHit(mrSampleIdx, distance, intensity, laserRetro, entityId, absPointVelocity, relPointVelocity, radialSpeed,
 	                wNormal, incidentAngle);
-
-	//	printf("sample idx: %d distance: %f xyz: %f %f %f mr samples xyz: %f %f %f\n", mrSampleIdx, distance,
-	//	       hitWorldSeenBySensor.x(), hitWorldSeenBySensor.y(), hitWorldSeenBySensor.z(), ctx.mrSamples.xyz[mrSampleIdx].x(),
-	//	       ctx.mrSamples.xyz[mrSampleIdx].y(), ctx.mrSamples.xyz[mrSampleIdx].z());
-
-	//	saveRayResult<true>(hitWorldSeenBySensor, distance, intensity, entityId, absPointVelocity, relPointVelocity, radialSpeed,
-	//	                    wNormal, incidentAngle, laserRetro);
 }
 
 extern "C" __global__ void __anyhit__() {}
@@ -364,67 +318,3 @@ __device__ void saveBeamSharedData(int beamIdx, const Mat3x4f& rayLocal)
 		}
 	}
 }
-
-//__device__ void saveNonHitRayResult(float nonHitDistance)
-//{
-//	Mat3x4f ray = ctx.raysWorld[optixGetLaunchIndex().x];
-//	Vec3f origin = ray * Vec3f{0, 0, 0};
-//	Vec3f dir = ray * Vec3f{0, 0, 1} - origin;
-//	Vec3f displacement = dir.normalized() * nonHitDistance;
-//	displacement = {isnan(displacement.x()) ? 0 : displacement.x(), isnan(displacement.y()) ? 0 : displacement.y(),
-//	                isnan(displacement.z()) ? 0 : displacement.z()};
-//	Vec3f xyz = origin + displacement;
-//	saveRayResult<false>(xyz, nonHitDistance, 0, RGL_ENTITY_INVALID_ID, Vec3f{NAN}, Vec3f{NAN}, 0.0f, Vec3f{NAN}, NAN, 0.0f);
-//}
-
-//template<bool isFinite>
-//__device__ void saveRayResult(const Vec3f& xyz, float distance, float intensity, const int objectID, const Vec3f& absVelocity,
-//                              const Vec3f& relVelocity, float radialSpeed, const Vec3f& normal, float incidentAngle,
-//                              float laserRetro)
-//{
-//	const int beamIdx = static_cast<int>(optixGetLaunchIndex().x);
-//	if (ctx.xyz != nullptr) {
-//		// Return actual XYZ of the hit point or infinity vector.
-//		ctx.xyz[beamIdx] = xyz;
-//	}
-//	if (ctx.isHit != nullptr) {
-//		ctx.isHit[beamIdx] = isFinite;
-//	}
-//	if (ctx.rayIdx != nullptr) {
-//		ctx.rayIdx[beamIdx] = beamIdx;
-//	}
-//	if (ctx.ringIdx != nullptr && ctx.ringIds != nullptr) {
-//		ctx.ringIdx[beamIdx] = ctx.ringIds[beamIdx % ctx.ringIdsCount];
-//	}
-//	if (ctx.distance != nullptr) {
-//		ctx.distance[beamIdx] = distance;
-//	}
-//	if (ctx.intensityF32 != nullptr) {
-//		ctx.intensityF32[beamIdx] = intensity;
-//	}
-//	if (ctx.intensityU8 != nullptr) {
-//		// intensity < 0 not possible
-//		ctx.intensityU8[beamIdx] = intensity < UINT8_MAX ? static_cast<uint8_t>(std::round(intensity)) : UINT8_MAX;
-//	}
-//	if (ctx.entityId != nullptr) {
-//		ctx.entityId[beamIdx] = isFinite ? objectID : RGL_ENTITY_INVALID_ID;
-//	}
-//	if (ctx.pointAbsVelocity != nullptr) {
-//		ctx.pointAbsVelocity[beamIdx] = absVelocity;
-//	}
-//	if (ctx.pointRelVelocity != nullptr) {
-//		ctx.pointRelVelocity[beamIdx] = relVelocity;
-//	}
-//	if (ctx.radialSpeed != nullptr) {
-//		ctx.radialSpeed[beamIdx] = radialSpeed;
-//	}
-//	if (ctx.normal != nullptr) {
-//		ctx.normal[beamIdx] = normal;
-//	}
-//	if (ctx.incidentAngle != nullptr) {
-//		ctx.incidentAngle[beamIdx] = incidentAngle;
-//	}
-//	if (ctx.laserRetro != nullptr) {
-//		ctx.laserRetro[beamIdx] = laserRetro;
-//	}
-//}

--- a/src/gpu/optixPrograms.cu
+++ b/src/gpu/optixPrograms.cu
@@ -56,9 +56,9 @@ extern "C" __global__ void __raygen__()
 	    ctx.rayOriginToWorld.inverse() *
 	    ray; // TODO(prybicki): instead of computing inverse, we should pass rays in local CF and then transform them to world CF.
 
+	saveNonHitBeamSamples(rayIdx, ctx.farNonHitDistance);
 	saveBeamSharedData(rayIdx, rayLocal);
 	if (ctx.rayMask != nullptr && ctx.rayMask[rayIdx] == 0) {
-		saveNonHitBeamSamples(rayIdx, ctx.farNonHitDistance);
 		return;
 	}
 
@@ -329,7 +329,8 @@ __device__ void saveSampleAsHit(int sampleIdx, float distance, float intensity, 
 
 __device__ void saveNonHitBeamSamples(int beamIdx, float nonHitDistance)
 {
-	for (int sampleIdx = beamIdx * MULTI_RETURN_BEAM_SAMPLES; sampleIdx < beamIdx * MULTI_RETURN_BEAM_SAMPLES + MULTI_RETURN_BEAM_SAMPLES; ++sampleIdx) {
+	for (int sampleIdx = beamIdx * MULTI_RETURN_BEAM_SAMPLES; sampleIdx < (beamIdx + 1) * MULTI_RETURN_BEAM_SAMPLES;
+	     ++sampleIdx) {
 		saveSampleAsNonHit(sampleIdx, nonHitDistance);
 	}
 }

--- a/src/graph/Interfaces.hpp
+++ b/src/graph/Interfaces.hpp
@@ -85,6 +85,8 @@ struct IPointsNode : virtual Node
 	virtual std::size_t getWidth() const = 0;
 	virtual std::size_t getHeight() const = 0;
 	virtual std::size_t getPointCount() const { return getWidth() * getHeight(); }
+	virtual rgl_return_mode_t getReturnMode() const = 0;
+	virtual std::size_t getReturnCount() const = 0;
 
 	virtual Mat3x4f getLookAtOriginTransform() const { return Mat3x4f::identity(); }
 
@@ -118,6 +120,8 @@ struct IPointsNodeSingleInput : IPointsNode
 	virtual bool isDense() const override { return input->isDense(); }
 	virtual size_t getWidth() const override { return input->getWidth(); }
 	virtual size_t getHeight() const override { return input->getHeight(); }
+	virtual rgl_return_mode_t getReturnMode() const override { return input->getReturnMode(); }
+	virtual size_t getReturnCount() const override { return input->getReturnCount(); }
 
 	virtual Mat3x4f getLookAtOriginTransform() const override { return input->getLookAtOriginTransform(); }
 

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -138,7 +138,13 @@ struct RaytraceNode : IPointsNode
 	void setNonHitDistanceValues(float nearDistance, float farDistance);
 	void setNonHitsMask(const int8_t* maskRaw, size_t maskPointCount);
 	void setDefaultIntensity(float intensity) { defaultIntensity = intensity; }
-	void setReturnMode(rgl_return_mode_t mode) { this->returnMode = mode; }
+	void setReturnMode(rgl_return_mode_t mode)
+	{
+		if (mode == RGL_RETURN_MODE_UNKNOWN) {
+			return;
+		}
+		returnMode = mode;
+	}
 	void setBeamDivergence(float hDivergenceRad, float vDivergenceRad)
 	{
 		hBeamHalfDivergenceRad = hDivergenceRad / 2.0f;

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -132,8 +132,6 @@ struct RaytraceNode : IPointsNode
 		return std::const_pointer_cast<const IAnyArray>(fieldData.at(field));
 	}
 
-	IAnyArray::ConstPtr getFieldDataMultiReturn(rgl_field_t field, rgl_return_type_t);
-
 	// RaytraceNode specific
 	void setVelocity(const Vec3f& linearVelocity, const Vec3f& angularVelocity);
 	void enableRayDistortion(bool enabled) { doApplyDistortion = enabled; }
@@ -263,35 +261,6 @@ private:
 
 	std::set<rgl_field_t> findFieldsToCompute();
 	void setFields(const std::set<rgl_field_t>& fields);
-};
-
-struct MultiReturnSwitchNode : IPointsNodeSingleInput
-{
-	using Ptr = std::shared_ptr<MultiReturnSwitchNode>;
-	void setParameters(rgl_return_type_t returnType) { this->returnType = returnType; }
-
-	// Node
-	void validateImpl() override
-	{
-		IPointsNodeSingleInput::validateImpl();
-		rtxInput = getExactlyOneInputOfType<RaytraceNode>();
-	}
-
-	void enqueueExecImpl() override {}
-
-	// Data getters
-	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override
-	{
-		// TODO(Pawel): Handle this somehow with new multi-return.
-		if (returnType == RGL_RETURN_TYPE_UNKNOWN) {
-			return rtxInput->getFieldData(field);
-		}
-		return rtxInput->getFieldDataMultiReturn(field, returnType);
-	}
-
-private:
-	rgl_return_type_t returnType;
-	RaytraceNode::Ptr rtxInput;
 };
 
 struct TransformPointsNode : IPointsNodeSingleInput

--- a/src/graph/RaytraceNode.cpp
+++ b/src/graph/RaytraceNode.cpp
@@ -145,27 +145,6 @@ void RaytraceNode::enqueueExecImpl()
 	                        requestCtxDev->getReadPtr());
 }
 
-IAnyArray::ConstPtr RaytraceNode::getFieldDataMultiReturn(rgl_field_t field, rgl_return_type_t type)
-{
-	//	if (type == RGL_RETURN_TYPE_FIRST) {
-	//		switch (field) {
-	//			case XYZ_VEC3_F32: return mrFirst.xyz;
-	//			case DISTANCE_F32: return mrFirst.distance;
-	//			case IS_HIT_I32: return mrFirst.isHit;
-	//			default: return getFieldData(field);
-	//		}
-	//	}
-	//	if (type == RGL_RETURN_TYPE_LAST) {
-	//		switch (field) {
-	//			case XYZ_VEC3_F32: return mrLast.xyz;
-	//			case DISTANCE_F32: return mrLast.distance;
-	//			case IS_HIT_I32: return mrLast.isHit;
-	//			default: return getFieldData(field);
-	//		}
-	//	}
-	throw InvalidPipeline(fmt::format("Unknown multi-return type ({})", type));
-}
-
 void RaytraceNode::setFields(const std::set<rgl_field_t>& fields)
 {
 	auto keyViewer = std::views::keys(fieldData);

--- a/src/returnModeUtils.h
+++ b/src/returnModeUtils.h
@@ -18,5 +18,5 @@
 
 inline size_t getReturnCount(rgl_return_mode_t returnMode)
 {
-	return static_cast<size_t>(returnMode >> RGL_RETURN_MODE_RETURNS_BIT_SHIFT);
+	return static_cast<size_t>(returnMode >> RGL_RETURN_MODE_BIT_SHIFT);
 }

--- a/src/returnModeUtils.h
+++ b/src/returnModeUtils.h
@@ -1,0 +1,22 @@
+// Copyright 2024 Robotec.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <rgl/api/core.h>
+
+inline size_t getReturnCount(rgl_return_mode_t returnMode)
+{
+	return static_cast<size_t>(returnMode >> RGL_RETURN_MODE_RETURNS_BIT_SHIFT);
+}

--- a/src/returnModeUtils.h
+++ b/src/returnModeUtils.h
@@ -14,9 +14,42 @@
 
 #pragma once
 
+#include <cassert>
+
+#include <macros/cuda.hpp>
 #include <rgl/api/core.h>
 
-inline size_t getReturnCount(rgl_return_mode_t returnMode)
+inline HostDevFn size_t getReturnCount(rgl_return_mode_t returnMode)
 {
 	return static_cast<size_t>(returnMode >> RGL_RETURN_MODE_BIT_SHIFT);
+}
+
+inline HostDevFn rgl_return_type_t getReturnType(rgl_return_mode_t returnMode, size_t returnIndex)
+{
+	return static_cast<rgl_return_type_t>((returnMode >> (returnIndex * RGL_RETURN_TYPE_BIT_SHIFT)) & 0xff);
+}
+
+inline HostFn const std::string& getReturnTypeName(rgl_return_type_t returnType)
+{
+	// clang-format off
+	static const std::unordered_map<rgl_return_type_t, std::string> typeNames = {
+		{RGL_RETURN_TYPE_UNKNOWN, "Unknown"},
+		{RGL_RETURN_TYPE_FIRST, "First"},
+		{RGL_RETURN_TYPE_SECOND, "Second"},
+		{RGL_RETURN_TYPE_LAST, "Last"},
+	    {RGL_RETURN_TYPE_STRONGEST, "Strongest"},
+	    {RGL_RETURN_TYPE_SECOND_STRONGEST, "SecondStrongest"},
+	};
+	// clang-format on
+	assert(typeNames.find(returnType) != typeNames.cend());
+	return typeNames.at(returnType);
+}
+
+inline HostFn std::string getReturnModeName(rgl_return_mode_t returnMode)
+{
+	std::string returnModeName = getReturnTypeName(getReturnType(returnMode, 0));
+	for (size_t returnIdx = 1; returnIdx < getReturnCount(returnMode); ++returnIdx) {
+		returnModeName += "-" + getReturnTypeName(getReturnType(returnMode, returnIdx));
+	}
+	return returnModeName;
 }

--- a/src/tape/TapeCore.hpp
+++ b/src/tape/TapeCore.hpp
@@ -57,6 +57,7 @@ class TapeCore
 	static void tape_node_raytrace_configure_mask(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_raytrace_configure_beam_divergence(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_raytrace_configure_default_intensity(const YAML::Node& yamlNode, PlaybackState& state);
+	static void tape_node_raytrace_configure_return_mode(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_format(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_yield(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_compact(const YAML::Node& yamlNode, PlaybackState& state);
@@ -117,6 +118,8 @@ class TapeCore
 		                      TapeCore::tape_node_raytrace_configure_beam_divergence),
 		    TAPE_CALL_MAPPING("rgl_node_raytrace_configure_default_intensity",
 		                      TapeCore::tape_node_raytrace_configure_default_intensity),
+		    TAPE_CALL_MAPPING("rgl_node_raytrace_configure_return_mode",
+		                      TapeCore::tape_node_raytrace_configure_return_mode),
 		    TAPE_CALL_MAPPING("rgl_node_points_format", TapeCore::tape_node_points_format),
 		    TAPE_CALL_MAPPING("rgl_node_points_yield", TapeCore::tape_node_points_yield),
 		    TAPE_CALL_MAPPING("rgl_node_points_compact", TapeCore::tape_node_points_compact),

--- a/src/tape/TapeCore.hpp
+++ b/src/tape/TapeCore.hpp
@@ -72,7 +72,6 @@ class TapeCore
 	static void tape_node_gaussian_noise_angular_ray(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_gaussian_noise_angular_hitpoint(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_gaussian_noise_distance(const YAML::Node& yamlNode, PlaybackState& state);
-	static void tape_node_multi_return_switch(const YAML::Node& yamlNode, PlaybackState& state);
 
 	// Called once in the translation unit
 	static inline bool autoExtendTapeFunctions = std::invoke([]() {
@@ -134,7 +133,6 @@ class TapeCore
 		    TAPE_CALL_MAPPING("rgl_node_gaussian_noise_angular_ray", TapeCore::tape_node_gaussian_noise_angular_ray),
 		    TAPE_CALL_MAPPING("rgl_node_gaussian_noise_angular_hitpoint", TapeCore::tape_node_gaussian_noise_angular_hitpoint),
 		    TAPE_CALL_MAPPING("rgl_node_gaussian_noise_distance", TapeCore::tape_node_gaussian_noise_distance),
-		    TAPE_CALL_MAPPING("rgl_node_multi_return_switch", TapeCore::tape_node_multi_return_switch),
 		};
 		TapePlayer::extendTapeFunctions(tapeFunctions);
 		return true;

--- a/test/include/helpers/graphHelpers.hpp
+++ b/test/include/helpers/graphHelpers.hpp
@@ -44,6 +44,9 @@ struct EmptyNode : IPointsNode, INoInputNode
 	bool hasField(rgl_field_t field) const override { return true; }
 	size_t getWidth() const override { return 0; }
 	size_t getHeight() const override { return 0; }
+	rgl_return_mode_t getReturnMode() const override { return RGL_RETURN_MODE_UNKNOWN; }
+	size_t getReturnCount() const override { return 0; }
+
 	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override { return createArray<DeviceAsyncArray>(field, arrayMgr); }
 
 protected:

--- a/test/include/helpers/graphHelpers.hpp
+++ b/test/include/helpers/graphHelpers.hpp
@@ -44,7 +44,7 @@ struct EmptyNode : IPointsNode, INoInputNode
 	bool hasField(rgl_field_t field) const override { return true; }
 	size_t getWidth() const override { return 0; }
 	size_t getHeight() const override { return 0; }
-	rgl_return_mode_t getReturnMode() const override { return RGL_RETURN_MODE_UNKNOWN; }
+	rgl_return_mode_t getReturnMode() const override { return RGL_RETURN_UNKNOWN; }
 	size_t getReturnCount() const override { return 0; }
 
 	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override { return createArray<DeviceAsyncArray>(field, arrayMgr); }

--- a/test/include/helpers/sceneHelpers.hpp
+++ b/test/include/helpers/sceneHelpers.hpp
@@ -5,6 +5,7 @@
 
 #include <helpers/commonHelpers.hpp>
 #include <helpers/geometryData.hpp>
+#include <helpers/textureHelpers.hpp>
 
 #include <math/Mat3x4f.hpp>
 #include "stl_reader.h"
@@ -28,9 +29,19 @@ static rgl_entity_t makeEntity(rgl_mesh_t mesh = nullptr)
 	return entity;
 }
 
-static inline rgl_entity_t spawnCubeOnScene(const Mat3x4f& transform, std::optional<int> id = std::nullopt)
+static inline rgl_entity_t spawnCubeOnScene(const Mat3x4f& transform, std::optional<int> id = std::nullopt, std::optional<int32_t> intensity = std::nullopt)
 {
-	rgl_entity_t boxEntity = makeEntity(makeCubeMesh());
+	rgl_mesh_t mesh = makeCubeMesh();
+	rgl_entity_t boxEntity = makeEntity(mesh);
+
+	if (intensity.has_value()) {
+		EXPECT_RGL_SUCCESS(rgl_mesh_set_texture_coords(mesh, cubeUVs, ARRAY_SIZE(cubeUVs)));
+
+		const auto colorTexture = generateStaticColorTexture(1, 1, intensity.value());
+		rgl_texture_t rglTexture = nullptr;
+		EXPECT_RGL_SUCCESS(rgl_texture_create(&rglTexture, colorTexture.data(), 1, 1));
+		EXPECT_RGL_SUCCESS(rgl_entity_set_intensity_texture(boxEntity, rglTexture));
+	}
 
 	auto rglTransform = transform.toRGL();
 	EXPECT_RGL_SUCCESS(rgl_entity_set_pose(boxEntity, &rglTransform));

--- a/test/src/TapeTest.cpp
+++ b/test/src/TapeTest.cpp
@@ -242,6 +242,9 @@ TEST_F(TapeTest, RecordPlayAllCalls)
 	float defaultIntensity = 1.1f;
 	EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_default_intensity(raytrace, defaultIntensity));
 
+	rgl_return_mode_t returnMode = RGL_RETURN_FIRST;
+	EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_return_mode(raytrace, returnMode));
+
 	rgl_node_t format = nullptr;
 	std::vector<rgl_field_t> fields = {RGL_FIELD_XYZ_VEC3_F32, RGL_FIELD_DISTANCE_F32};
 	EXPECT_RGL_SUCCESS(rgl_node_points_format(&format, fields.data(), fields.size()));

--- a/test/src/graph/multiReturnTest.cpp
+++ b/test/src/graph/multiReturnTest.cpp
@@ -138,32 +138,32 @@ TEST_F(GraphMultiReturn, vlp16_data_compare)
 	// Verify the output
 	const float epsilon = 1e-4f;
 
-	//	const auto mrFirstOutPointcloud = TestPointCloud::createFromNode(mrFormatFirst, fields);
-	//	const auto mrFirstIsHits = mrFirstOutPointcloud.getFieldValues<IS_HIT_I32>();
-	//	const auto mrFirstPoints = mrFirstOutPointcloud.getFieldValues<XYZ_VEC3_F32>();
-	//	const auto mrFirstDistances = mrFirstOutPointcloud.getFieldValues<DISTANCE_F32>();
-	//	const auto expectedFirstPoint = Vec3f{CUBE_HALF_EDGE, 0.0f, 0.0f};
-	//	EXPECT_EQ(mrFirstOutPointcloud.getPointCount(), raysTf.size());
-	//	EXPECT_TRUE(mrFirstIsHits.at(0));
-	//	EXPECT_NEAR(mrFirstDistances.at(0), lidarCubeFaceDist, epsilon);
-	//	EXPECT_NEAR(mrFirstPoints.at(0).x(), expectedFirstPoint.x(), epsilon);
-	//	EXPECT_NEAR(mrFirstPoints.at(0).y(), expectedFirstPoint.y(), epsilon);
-	//	EXPECT_NEAR(mrFirstPoints.at(0).z(), expectedFirstPoint.z(), epsilon);
-	//
-	//	const auto mrLastOutPointcloud = TestPointCloud::createFromNode(mrFormatLast, fields);
-	//	const auto mrLastIsHits = mrLastOutPointcloud.getFieldValues<IS_HIT_I32>();
-	//	const auto mrLastPoints = mrLastOutPointcloud.getFieldValues<XYZ_VEC3_F32>();
-	//	const auto mrLastDistances = mrLastOutPointcloud.getFieldValues<DISTANCE_F32>();
-	//	const float expectedDiameter = std::max(vlp16LidarHBeamDiameter, vlp16LidarVBeamDiameter);
-	//	const auto expectedLastDistance = static_cast<float>(sqrt(pow(lidarCubeFaceDist, 2) + pow(expectedDiameter / 2, 2)));
-	//	// Substract because the ray is pointing as is the negative X axis
-	//	const auto expectedLastPoint = lidarTransl - Vec3f{expectedLastDistance, 0.0f, 0.0f};
-	//	EXPECT_EQ(mrLastOutPointcloud.getPointCount(), raysTf.size());
-	//	EXPECT_TRUE(mrLastIsHits.at(0));
-	//	EXPECT_NEAR(mrLastDistances.at(0), expectedLastDistance, epsilon);
-	//	EXPECT_NEAR(mrLastPoints.at(0).x(), expectedLastPoint.x(), epsilon);
-	//	EXPECT_NEAR(mrLastPoints.at(0).y(), expectedLastPoint.y(), epsilon);
-	//	EXPECT_NEAR(mrLastPoints.at(0).z(), expectedLastPoint.z(), epsilon);
+	const auto outPointcloud = TestPointCloud::createFromNode(format, fields);
+	const auto isHits = outPointcloud.getFieldValues<IS_HIT_I32>();
+	const auto points = outPointcloud.getFieldValues<XYZ_VEC3_F32>();
+	const auto distances = outPointcloud.getFieldValues<DISTANCE_F32>();
+	EXPECT_EQ(isHits.size(), 2); // Single beam, first and last return.
+	EXPECT_EQ(points.size(), isHits.size());
+	EXPECT_EQ(distances.size(), isHits.size());
+
+	// First return.
+	const auto expectedFirstPoint = Vec3f{CUBE_HALF_EDGE, 0.0f, 0.0f};
+	EXPECT_TRUE(isHits.at(0));
+	EXPECT_NEAR(distances.at(0), lidarCubeFaceDist, epsilon);
+	EXPECT_NEAR(points.at(0).x(), expectedFirstPoint.x(), epsilon);
+	EXPECT_NEAR(points.at(0).y(), expectedFirstPoint.y(), epsilon);
+	EXPECT_NEAR(points.at(0).z(), expectedFirstPoint.z(), epsilon);
+
+	// Second return.
+	const float expectedDiameter = std::max(vlp16LidarHBeamDiameter, vlp16LidarVBeamDiameter);
+	const auto expectedLastDistance = static_cast<float>(sqrt(pow(lidarCubeFaceDist, 2) + pow(expectedDiameter / 2, 2)));
+	// Subtract because the ray is pointing as is the negative X axis.
+	const auto expectedLastPoint = lidarTransl - Vec3f{expectedLastDistance, 0.0f, 0.0f};
+	EXPECT_TRUE(isHits.at(1));
+	EXPECT_NEAR(distances.at(1), expectedLastDistance, epsilon);
+	EXPECT_NEAR(points.at(1).x(), expectedLastPoint.x(), epsilon);
+	EXPECT_NEAR(points.at(1).y(), expectedLastPoint.y(), epsilon);
+	EXPECT_NEAR(points.at(1).z(), expectedLastPoint.z(), epsilon);
 }
 
 #if RGL_BUILD_ROS2_EXTENSION

--- a/test/src/graph/multiReturnTest.cpp
+++ b/test/src/graph/multiReturnTest.cpp
@@ -45,46 +45,35 @@ protected:
 	const std::vector<rgl_field_t> fields = {XYZ_VEC3_F32, IS_HIT_I32, DISTANCE_F32,
 	                                         RETURN_TYPE_U8 /*, INTENSITY_F32, ENTITY_ID_I32*/};
 
-	rgl_node_t rays = nullptr, mrRays = nullptr, cameraRays = nullptr, transform = nullptr, mrTransform = nullptr,
-	           cameraTransform = nullptr, raytrace = nullptr, mrRaytrace = nullptr, cameraRaytrace = nullptr, mrFirst = nullptr,
-	           mrLast = nullptr, format = nullptr, mrFormatFirst = nullptr, mrFormatLast = nullptr, cameraFormat = nullptr,
-	           publish = nullptr, cameraPublish = nullptr, mrPublishFirst = nullptr, mrPublishLast = nullptr,
-	           compactFirst = nullptr, compactLast = nullptr;
+	rgl_node_t rays = nullptr, cameraRays = nullptr, transform = nullptr, cameraTransform = nullptr, raytrace = nullptr,
+	           cameraRaytrace = nullptr, format = nullptr, cameraFormat = nullptr, publish = nullptr, cameraPublish = nullptr,
+	           compact = nullptr;
 
 	void constructMRGraph(const std::vector<rgl_mat3x4f>& raysTf, const rgl_mat3x4f& lidarPose, const float hBeamDivAngle,
-	                      const float vBeamDivAngle, bool withPublish = false)
+	                      const float vBeamDivAngle, rgl_return_mode_t returnMode, bool withPublish = false)
 	{
-		EXPECT_RGL_SUCCESS(rgl_node_rays_from_mat3x4f(&mrRays, raysTf.data(), raysTf.size()));
-		EXPECT_RGL_SUCCESS(rgl_node_rays_transform(&mrTransform, &lidarPose));
-		EXPECT_RGL_SUCCESS(rgl_node_raytrace(&mrRaytrace, nullptr));
-		EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_beam_divergence(mrRaytrace, hBeamDivAngle, vBeamDivAngle));
-		EXPECT_RGL_SUCCESS(rgl_node_multi_return_switch(&mrFirst, RGL_RETURN_TYPE_FIRST));
-		EXPECT_RGL_SUCCESS(rgl_node_multi_return_switch(&mrLast, RGL_RETURN_TYPE_LAST));
-		EXPECT_RGL_SUCCESS(rgl_node_points_compact_by_field(&compactFirst, RGL_FIELD_IS_HIT_I32));
-		EXPECT_RGL_SUCCESS(rgl_node_points_compact_by_field(&compactLast, RGL_FIELD_IS_HIT_I32));
-		EXPECT_RGL_SUCCESS(rgl_node_points_format(&mrFormatFirst, fields.data(), fields.size()));
-		EXPECT_RGL_SUCCESS(rgl_node_points_format(&mrFormatLast, fields.data(), fields.size()));
+		EXPECT_RGL_SUCCESS(rgl_node_rays_from_mat3x4f(&rays, raysTf.data(), raysTf.size()));
+		EXPECT_RGL_SUCCESS(rgl_node_rays_transform(&transform, &lidarPose));
+		EXPECT_RGL_SUCCESS(rgl_node_raytrace(&raytrace, nullptr));
+		EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_beam_divergence(raytrace, hBeamDivAngle, vBeamDivAngle));
+		EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_return_mode(raytrace, returnMode));
+		EXPECT_RGL_SUCCESS(rgl_node_points_compact_by_field(&compact, RGL_FIELD_IS_HIT_I32));
+		EXPECT_RGL_SUCCESS(rgl_node_points_format(&format, fields.data(), fields.size()));
 #if RGL_BUILD_ROS2_EXTENSION
 		if (withPublish) {
-			EXPECT_RGL_SUCCESS(rgl_node_points_ros2_publish(&mrPublishFirst, "MRTest_First", "world"));
-			EXPECT_RGL_SUCCESS(rgl_node_points_ros2_publish(&mrPublishLast, "MRTest_Last", "world"));
+			EXPECT_RGL_SUCCESS(rgl_node_points_ros2_publish(&publish, "MRTest_MultiReturnCloud", "world"));
 		}
 #else
 		if (withPublish) {
 			GTEST_SKIP() << "Publishing is not supported without ROS2 extension. Skippping the test.";
 		}
 #endif
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrRays, mrTransform));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrTransform, mrRaytrace));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrRaytrace, mrFirst));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrRaytrace, mrLast));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrFirst, compactFirst));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrLast, compactLast));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(compactFirst, mrFormatFirst));
-		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(compactLast, mrFormatLast));
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(rays, transform));
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(transform, raytrace));
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(raytrace, compact));
+		EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(compact, format));
 		if (withPublish) {
-			EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrFormatFirst, mrPublishFirst));
-			EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(mrFormatLast, mrPublishLast));
+			EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(format, publish));
 		}
 	}
 
@@ -142,39 +131,39 @@ TEST_F(GraphMultiReturn, vlp16_data_compare)
 	// Scene
 	spawnCubeOnScene(Mat3x4f::identity());
 
-	constructMRGraph(raysTf, lidarPose, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence);
+	constructMRGraph(raysTf, lidarPose, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence, RGL_RETURN_FIRST_LAST);
 
-	EXPECT_RGL_SUCCESS(rgl_graph_run(mrRays));
+	EXPECT_RGL_SUCCESS(rgl_graph_run(rays));
 
 	// Verify the output
 	const float epsilon = 1e-4f;
 
-	const auto mrFirstOutPointcloud = TestPointCloud::createFromNode(mrFormatFirst, fields);
-	const auto mrFirstIsHits = mrFirstOutPointcloud.getFieldValues<IS_HIT_I32>();
-	const auto mrFirstPoints = mrFirstOutPointcloud.getFieldValues<XYZ_VEC3_F32>();
-	const auto mrFirstDistances = mrFirstOutPointcloud.getFieldValues<DISTANCE_F32>();
-	const auto expectedFirstPoint = Vec3f{CUBE_HALF_EDGE, 0.0f, 0.0f};
-	EXPECT_EQ(mrFirstOutPointcloud.getPointCount(), raysTf.size());
-	EXPECT_TRUE(mrFirstIsHits.at(0));
-	EXPECT_NEAR(mrFirstDistances.at(0), lidarCubeFaceDist, epsilon);
-	EXPECT_NEAR(mrFirstPoints.at(0).x(), expectedFirstPoint.x(), epsilon);
-	EXPECT_NEAR(mrFirstPoints.at(0).y(), expectedFirstPoint.y(), epsilon);
-	EXPECT_NEAR(mrFirstPoints.at(0).z(), expectedFirstPoint.z(), epsilon);
-
-	const auto mrLastOutPointcloud = TestPointCloud::createFromNode(mrFormatLast, fields);
-	const auto mrLastIsHits = mrLastOutPointcloud.getFieldValues<IS_HIT_I32>();
-	const auto mrLastPoints = mrLastOutPointcloud.getFieldValues<XYZ_VEC3_F32>();
-	const auto mrLastDistances = mrLastOutPointcloud.getFieldValues<DISTANCE_F32>();
-	const float expectedDiameter = std::max(vlp16LidarHBeamDiameter, vlp16LidarVBeamDiameter);
-	const auto expectedLastDistance = static_cast<float>(sqrt(pow(lidarCubeFaceDist, 2) + pow(expectedDiameter / 2, 2)));
-	// Substract because the ray is pointing as is the negative X axis
-	const auto expectedLastPoint = lidarTransl - Vec3f{expectedLastDistance, 0.0f, 0.0f};
-	EXPECT_EQ(mrLastOutPointcloud.getPointCount(), raysTf.size());
-	EXPECT_TRUE(mrLastIsHits.at(0));
-	EXPECT_NEAR(mrLastDistances.at(0), expectedLastDistance, epsilon);
-	EXPECT_NEAR(mrLastPoints.at(0).x(), expectedLastPoint.x(), epsilon);
-	EXPECT_NEAR(mrLastPoints.at(0).y(), expectedLastPoint.y(), epsilon);
-	EXPECT_NEAR(mrLastPoints.at(0).z(), expectedLastPoint.z(), epsilon);
+	//	const auto mrFirstOutPointcloud = TestPointCloud::createFromNode(mrFormatFirst, fields);
+	//	const auto mrFirstIsHits = mrFirstOutPointcloud.getFieldValues<IS_HIT_I32>();
+	//	const auto mrFirstPoints = mrFirstOutPointcloud.getFieldValues<XYZ_VEC3_F32>();
+	//	const auto mrFirstDistances = mrFirstOutPointcloud.getFieldValues<DISTANCE_F32>();
+	//	const auto expectedFirstPoint = Vec3f{CUBE_HALF_EDGE, 0.0f, 0.0f};
+	//	EXPECT_EQ(mrFirstOutPointcloud.getPointCount(), raysTf.size());
+	//	EXPECT_TRUE(mrFirstIsHits.at(0));
+	//	EXPECT_NEAR(mrFirstDistances.at(0), lidarCubeFaceDist, epsilon);
+	//	EXPECT_NEAR(mrFirstPoints.at(0).x(), expectedFirstPoint.x(), epsilon);
+	//	EXPECT_NEAR(mrFirstPoints.at(0).y(), expectedFirstPoint.y(), epsilon);
+	//	EXPECT_NEAR(mrFirstPoints.at(0).z(), expectedFirstPoint.z(), epsilon);
+	//
+	//	const auto mrLastOutPointcloud = TestPointCloud::createFromNode(mrFormatLast, fields);
+	//	const auto mrLastIsHits = mrLastOutPointcloud.getFieldValues<IS_HIT_I32>();
+	//	const auto mrLastPoints = mrLastOutPointcloud.getFieldValues<XYZ_VEC3_F32>();
+	//	const auto mrLastDistances = mrLastOutPointcloud.getFieldValues<DISTANCE_F32>();
+	//	const float expectedDiameter = std::max(vlp16LidarHBeamDiameter, vlp16LidarVBeamDiameter);
+	//	const auto expectedLastDistance = static_cast<float>(sqrt(pow(lidarCubeFaceDist, 2) + pow(expectedDiameter / 2, 2)));
+	//	// Substract because the ray is pointing as is the negative X axis
+	//	const auto expectedLastPoint = lidarTransl - Vec3f{expectedLastDistance, 0.0f, 0.0f};
+	//	EXPECT_EQ(mrLastOutPointcloud.getPointCount(), raysTf.size());
+	//	EXPECT_TRUE(mrLastIsHits.at(0));
+	//	EXPECT_NEAR(mrLastDistances.at(0), expectedLastDistance, epsilon);
+	//	EXPECT_NEAR(mrLastPoints.at(0).x(), expectedLastPoint.x(), epsilon);
+	//	EXPECT_NEAR(mrLastPoints.at(0).y(), expectedLastPoint.y(), epsilon);
+	//	EXPECT_NEAR(mrLastPoints.at(0).z(), expectedLastPoint.z(), epsilon);
 }
 
 #if RGL_BUILD_ROS2_EXTENSION
@@ -214,29 +203,16 @@ TEST_F(GraphMultiReturn, cube_in_motion)
 	                                      spawnCubeOnScene(entitiesTransforms.at(1))};
 
 	// Lidar with MR
-	constructMRGraph(raysTf, lidarPose, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence, true);
-
-	// Lidar without MR
-	EXPECT_RGL_SUCCESS(rgl_node_rays_from_mat3x4f(&rays, raysTf.data(), raysTf.size()));
-	EXPECT_RGL_SUCCESS(rgl_node_rays_transform(&transform, &lidarPose));
-	EXPECT_RGL_SUCCESS(rgl_node_raytrace(&raytrace, nullptr));
-	EXPECT_RGL_SUCCESS(
-	    rgl_node_raytrace_configure_beam_divergence(raytrace, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence));
-	EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_return_mode(raytrace, RGL_RETURN_FIRST_LAST));
-	EXPECT_RGL_SUCCESS(rgl_node_points_format(&format, fields.data(), fields.size()));
-	EXPECT_RGL_SUCCESS(rgl_node_points_ros2_publish(&publish, "MRTest_Lidar_Without_MR", "world"));
-	EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(rays, transform));
-	EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(transform, raytrace));
-	EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(raytrace, format));
-	EXPECT_RGL_SUCCESS(rgl_graph_node_add_child(format, publish));
+	constructMRGraph(raysTf, lidarPose, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence, RGL_RETURN_FIRST_LAST, true);
 
 	// Camera
 	const rgl_mat3x4f cameraPose = Mat3x4f::TRS(Vec3f{-8.0f, 1.0f, 5.0f}, {90.0f, 30.0f, -70.0f}).toRGL();
 	constructCameraGraph(cameraPose);
 
-	std::vector<rgl_return_mode_t> returnModes = {RGL_RETURN_FIRST, RGL_RETURN_SECOND, RGL_RETURN_LAST, RGL_RETURN_STRONGEST};
-//	std::vector<rgl_return_mode_t> returnModes = {RGL_RETURN_LAST_STRONGEST, RGL_RETURN_FIRST_LAST, RGL_RETURN_FIRST_STRONGEST,
-//	                                              RGL_RETURN_STRONGEST_SECOND_STRONGEST, RGL_RETURN_FIRST_SECOND};
+	//	std::vector<rgl_return_mode_t> returnModes = {RGL_RETURN_FIRST, RGL_RETURN_SECOND, RGL_RETURN_LAST, RGL_RETURN_STRONGEST};
+	//	std::vector<rgl_return_mode_t> returnModes = {RGL_RETURN_FIRST, RGL_RETURN_LAST, RGL_RETURN_FIRST_LAST};
+	//	std::vector<rgl_return_mode_t> returnModes = {RGL_RETURN_LAST_STRONGEST, RGL_RETURN_FIRST_LAST, RGL_RETURN_FIRST_STRONGEST,
+	//	                                              RGL_RETURN_STRONGEST_SECOND_STRONGEST, RGL_RETURN_FIRST_SECOND};
 	int returnModeIdx = -1;
 	//std::vector<rgl_vec3f> points;
 
@@ -244,15 +220,15 @@ TEST_F(GraphMultiReturn, cube_in_motion)
 	while (true) {
 
 		const auto newPose = (entitiesTransforms.at(0) *
-		                      Mat3x4f::translation(0.0f, std::abs(std::sin(frameId * 0.05f)) * gapRange.y(), 0.0f))
+		                      Mat3x4f::translation(0.0f, std::abs(2 * std::sin(frameId * 0.05f)) * gapRange.y() - 0.9f, 0.0f))
 		                         .toRGL();
 		EXPECT_RGL_SUCCESS(rgl_entity_set_pose(entities.at(0), &newPose));
 
-//		if (frameId % 200 == 0) {
-//			returnModeIdx = ++returnModeIdx % static_cast<int>(returnModes.size());
-//			EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_return_mode(raytrace, returnModes[returnModeIdx]));
-//			std::cout << "Changed return mode to: " << returnModes[returnModeIdx] << std::endl;
-//		}
+		//		if (frameId % 200 == 0) {
+		//			returnModeIdx = ++returnModeIdx % static_cast<int>(returnModes.size());
+		//			EXPECT_RGL_SUCCESS(rgl_node_raytrace_configure_return_mode(raytrace, returnModes[returnModeIdx]));
+		//			//std::cout << "Changed return mode to: " << returnModes[returnModeIdx] << std::endl;
+		//		}
 
 		ASSERT_RGL_SUCCESS(rgl_graph_run(cameraRays));
 		ASSERT_RGL_SUCCESS(rgl_graph_run(rays));
@@ -308,7 +284,7 @@ TEST_F(GraphMultiReturn, stairs)
 	const rgl_mat3x4f lidarPose{(Mat3x4f::translation(lidarTransl + stairsTranslation)).toRGL()};
 
 	// Lidar with MR
-	constructMRGraph(raysTf, lidarPose, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence, true);
+	constructMRGraph(raysTf, lidarPose, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence, RGL_RETURN_FIRST_LAST, true);
 
 	// Camera
 	rgl_mat3x4f cameraPose = Mat3x4f::translation({0.0f, -1.5f, stepHeight * 3 + 1.0f}).toRGL();
@@ -318,10 +294,9 @@ TEST_F(GraphMultiReturn, stairs)
 	int frameId = 0;
 	while (true) {
 		const float newVBeamDivAngle = vlp16LidarVBeamDivergence + std::sin(frameId * 0.1f) * vlp16LidarVBeamDivergence;
-		ASSERT_RGL_SUCCESS(
-		    rgl_node_raytrace_configure_beam_divergence(mrRaytrace, vlp16LidarHBeamDivergence, newVBeamDivAngle));
+		ASSERT_RGL_SUCCESS(rgl_node_raytrace_configure_beam_divergence(raytrace, vlp16LidarHBeamDivergence, newVBeamDivAngle));
 
-		ASSERT_RGL_SUCCESS(rgl_graph_run(mrRaytrace));
+		ASSERT_RGL_SUCCESS(rgl_graph_run(raytrace));
 
 		std::this_thread::sleep_for(100ms);
 		frameId += 1;
@@ -353,11 +328,10 @@ TEST_F(GraphMultiReturn, multiple_ray_beams)
 		}
 	}
 	const rgl_mat3x4f lidarPose = Mat3x4f::identity().toRGL();
-	const float beamDivAngle = vlp16LidarHBeamDivergence;
-	constructMRGraph(vlp16RaysTf, lidarPose, beamDivAngle, true);
+	constructMRGraph(vlp16RaysTf, lidarPose, vlp16LidarHBeamDivergence, vlp16LidarVBeamDivergence, RGL_RETURN_FIRST_LAST, true);
 
 	ASSERT_RGL_SUCCESS(rgl_graph_run(cameraRays));
-	ASSERT_RGL_SUCCESS(rgl_graph_run(mrRays));
+	ASSERT_RGL_SUCCESS(rgl_graph_run(rays));
 }
 
 /**

--- a/test/src/graph/multiReturnTest.cpp
+++ b/test/src/graph/multiReturnTest.cpp
@@ -221,9 +221,11 @@ TEST_F(GraphMultiReturn, cube_in_motion)
 	};
 
 	while (true) {
-		const auto newPose = (entitiesTransforms.at(0) *
-		                      Mat3x4f::translation(0.0f, std::abs(2 * std::sin(frameId * 0.05f)) * gapRange.y() - 0.9f, 0.0f))
-		                         .toRGL();
+		const auto newPose =
+		    (entitiesTransforms.at(0) *
+		     Mat3x4f::translation(0.0f, std::abs(2 * std::sin(static_cast<float>(frameId) * 0.05f)) * gapRange.y() - 0.9f,
+		                          0.0f))
+		        .toRGL();
 		EXPECT_RGL_SUCCESS(rgl_entity_set_pose(entities.at(0), &newPose));
 
 		if (frameId++ % framesPerSwitch == 0) {
@@ -282,7 +284,8 @@ TEST_F(GraphMultiReturn, stairs)
 
 	int frameId = 0;
 	while (true) {
-		const float newVBeamDivAngle = vlp16LidarVBeamDivergence + std::sin(frameId * 0.1f) * vlp16LidarVBeamDivergence;
+		const float newVBeamDivAngle = vlp16LidarVBeamDivergence +
+		                               std::sin(static_cast<float>(frameId) * 0.1f) * vlp16LidarVBeamDivergence;
 		ASSERT_RGL_SUCCESS(rgl_node_raytrace_configure_beam_divergence(raytrace, vlp16LidarHBeamDivergence, newVBeamDivAngle));
 
 		ASSERT_RGL_SUCCESS(rgl_graph_run(raytrace));
@@ -313,7 +316,8 @@ TEST_F(GraphMultiReturn, multiple_ray_beams)
 
 	for (int i = 0; i < horizontalSteps; ++i) {
 		for (const auto& velodyneVLP16Channel : vlp16Channels) {
-			vlp16RaysTf.emplace_back((Mat3x4f::rotationDeg(0.0f, 90.0f, resolution * i) * velodyneVLP16Channel).toRGL());
+			vlp16RaysTf.emplace_back(
+			    (Mat3x4f::rotationDeg(0.0f, 90.0f, resolution * static_cast<float>(i)) * velodyneVLP16Channel).toRGL());
 		}
 	}
 	const rgl_mat3x4f lidarPose = Mat3x4f::identity().toRGL();


### PR DESCRIPTION
### Description

This PRs introduces an update to RGL multi-return - more types are handled now (first, second, last, strongest and second strongest) and all RGL fields are handled. Moreover, this vastly simplifies an amount of effort to introduce multi-return for ROS 2 and UDP publishing.

A temporary downgrade is that multi-return samples are allocated even if beam divergence is set to zero. However, that was the case also before this update. This will be solved in close future PRs.

Multi-return modes and beam divergences are configurable at runtime.

### Testing

Run implemented unit tests - most important here is asyncStressTest. For runtime check I propose running cube_in_motion test from multiReturnTest suite - uncomment GTEST_SKIP there. Results are visible in RViz2 ("world" frame). Divergence is configured on beams, and return modes switch circularly in following order:
 - RGL_RETURN_FIRST
 - RGL_RETURN_LAST
 - RGL_RETURN_FIRST_LAST
