### PR TITLE
Add detection states in radar nodes

### DIFF
--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -730,6 +730,21 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 		Invalid = 255
 	};
 
+	struct DetectionState
+	{
+		float azimuth{};
+		float azimuthStd{};
+		float elevation{};
+		float elevationStd{};
+		float distance{};
+		float distanceStd{};
+		float radialSpeed{};
+		float radialSpeedStd{};
+		float rcs{0};
+		uint32_t detectionId{0};
+		uint32_t objectId{0};
+	};
+
 	struct ObjectBounds
 	{
 		Field<ENTITY_ID_I32>::type mostCommonEntityId = RGL_ENTITY_INVALID_ID;
@@ -737,6 +752,7 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 		Aabb3Df aabb{};
 		Vec3f absVelocity{};
 		Vec3f relVelocity{};
+		std::list<int> detectionIndices{};
 	};
 
 	struct ClassificationProbabilities
@@ -794,17 +810,19 @@ struct RadarTrackObjectsNode : IPointsNodeSingleInput
 	size_t getWidth() const override { return fieldData.empty() ? 0 : fieldData.begin()->second->getCount(); }
 	size_t getHeight() const override { return 1; } // In fact, this will be only a 1-dimensional array.
 
+	const std::vector<DetectionState>& getDetectionStates() const { return detectionStates; }
 	const std::list<ObjectState>& getObjectStates() const { return objectStates; }
 
 private:
 	Vec3f predictObjectPosition(const ObjectState& objectState, double deltaTimeMs) const;
 	void parseEntityIdToClassProbability(Field<ENTITY_ID_I32>::type entityId, ClassificationProbabilities& probabilities);
-	void createObjectState(const ObjectBounds& objectBounds, double currentTimeMs);
+	const ObjectState& createObjectState(const ObjectBounds& objectBounds, double currentTimeMs);
 	void updateObjectState(ObjectState& objectState, const Vec3f& updatedPosition, const Aabb3Df& updatedAabb,
 	                       ObjectStatus objectStatus, double currentTimeMs, double deltaTimeMs, const Vec3f& absVelocity,
 	                       const Vec3f& relVelocity);
 	void updateOutputData();
 
+	std::vector<DetectionState> detectionStates;
 	std::list<ObjectState> objectStates;
 	std::unordered_map<Field<ENTITY_ID_I32>::type, rgl_radar_object_class_t> entityIdsToClasses;
 	std::unordered_map<rgl_field_t, IAnyArray::Ptr> fieldData; // All should be DeviceAsyncArray
@@ -833,6 +851,7 @@ private:
 	HostPinnedArray<Field<ELEVATION_F32>::type>::Ptr elevationHostPtr = HostPinnedArray<Field<ELEVATION_F32>::type>::create();
 	HostPinnedArray<Field<RADIAL_SPEED_F32>::type>::Ptr radialSpeedHostPtr =
 	    HostPinnedArray<Field<RADIAL_SPEED_F32>::type>::create();
+	HostPinnedArray<Field<RCS_F32>::type>::Ptr rcsHostPtr = HostPinnedArray<Field<RCS_F32>::type>::create();
 	HostPinnedArray<Field<ENTITY_ID_I32>::type>::Ptr entityIdHostPtr = HostPinnedArray<Field<ENTITY_ID_I32>::type>::create();
 	HostPinnedArray<Field<RELATIVE_VELOCITY_VEC3_F32>::type>::Ptr velocityRelHostPtr =
 	    HostPinnedArray<Field<RELATIVE_VELOCITY_VEC3_F32>::type>::create();

--- a/src/graph/NodesCore.hpp
+++ b/src/graph/NodesCore.hpp
@@ -605,6 +605,15 @@ struct RadarPostprocessPointsNode : IPointsNodeSingleInput
 {
 	using Ptr = std::shared_ptr<RadarPostprocessPointsNode>;
 
+	struct ClusterStats
+	{
+		Aabb3Df aabb{};
+		float azimuthStd{0.0f};
+		float elevationStd{0.0f};
+		float distanceStd{0.0f};
+		float radialSpeedStd{0.0f};
+	};
+
 	void setParameters(const std::vector<rgl_radar_scope_t>& radarScopes, float rayAzimuthStepRad, float rayElevationStepRad,
 	                   float frequency, float powerTransmitted, float cumulativeDeviceGain, float receivedNoiseMean,
 	                   float receivedNoiseStDev);
@@ -623,7 +632,7 @@ struct RadarPostprocessPointsNode : IPointsNodeSingleInput
 	// Data getters
 	IAnyArray::ConstPtr getFieldData(rgl_field_t field) override;
 
-	const std::vector<Aabb3Df>& getClusterAabbs() const { return clusterAabbs; }
+	const std::vector<ClusterStats>& getClustersStats() const { return clustersStats; }
 
 private:
 	// Data containers
@@ -660,7 +669,7 @@ private:
 	float receivedNoiseStDevDb;
 
 	std::vector<rgl_radar_scope_t> radarScopes;
-	std::vector<Aabb3Df> clusterAabbs;
+	std::vector<ClusterStats> clustersStats;
 
 	std::random_device randomDevice;
 
@@ -681,11 +690,24 @@ private:
 		Field<RAY_IDX_U32>::type findDirectionalCenterIndex(const Field<AZIMUTH_F32>::type* azimuths,
 		                                                    const Field<ELEVATION_F32>::type* elevations) const;
 
+		Field<DISTANCE_F32>::type getMeanDistance() const;
+		Field<AZIMUTH_F32>::type getMeanAzimuth() const;
+		Field<RADIAL_SPEED_F32>::type getMeanRadialSpeed() const;
+		Field<ELEVATION_F32>::type getMeanElevation() const;
+
 		std::vector<Field<RAY_IDX_U32>::type> indices;
 		Vector<2, Field<DISTANCE_F32>::type> minMaxDistance;
 		Vector<2, Field<AZIMUTH_F32>::type> minMaxAzimuth;
 		Vector<2, Field<RADIAL_SPEED_F32>::type> minMaxRadialSpeed;
 		Vector<2, Field<ELEVATION_F32>::type> minMaxElevation; // For finding directional center only
+
+	private:
+		// These fields are utilized only for mean calculation.
+		Field<DISTANCE_F32>::type sumOfDistances;
+		Field<AZIMUTH_F32>::type sumOfAzimuths;
+		Field<RADIAL_SPEED_F32>::type sumOfRadialSpeeds;
+		Field<ELEVATION_F32>::type sumOfElevations;
+		uint32_t radialSpeedSamples = 0;
 	};
 };
 

--- a/src/graph/RadarPostprocessPointsNode.cpp
+++ b/src/graph/RadarPostprocessPointsNode.cpp
@@ -50,7 +50,7 @@ void RadarPostprocessPointsNode::validateImpl()
 	IPointsNodeSingleInput::validateImpl();
 
 	if (!input->isDense()) {
-		throw InvalidPipeline("RadarComputeEnergyPointsNode requires dense input");
+		throw InvalidPipeline("RadarPostprocessPointsNode requires dense input");
 	}
 
 	// Needed to clear cache because fields in the pipeline may have changed

--- a/src/graph/RadarPostprocessPointsNode.cpp
+++ b/src/graph/RadarPostprocessPointsNode.cpp
@@ -147,17 +147,36 @@ void RadarPostprocessPointsNode::enqueueExecImpl()
 	clusterSnrHost->resize(filteredIndicesHost.size(), false, false);
 
 	std::normal_distribution<float> gaussianNoise(receivedNoiseMeanDb, receivedNoiseStDevDb);
-	clusterAabbs.resize(clusters.size());
+	clustersStats.resize(clusters.size());
 
 	for (int clusterIdx = 0; clusterIdx < clusters.size(); ++clusterIdx) {
 		std::complex<float> AU = 0;
 		std::complex<float> AR = 0;
 		auto& cluster = clusters[clusterIdx];
-		auto& clusterAabb = clusterAabbs[clusterIdx];
-		clusterAabb.reset();
+		auto& clusterStats = clustersStats[clusterIdx];
+
+		clusterStats.aabb.reset();
+		clusterStats.azimuthStd = 0.0f;
+		clusterStats.elevationStd = 0.0f;
+		clusterStats.distanceStd = 0.0f;
+		clusterStats.radialSpeedStd = 0.0f;
+
+		const auto meanAzimuth = cluster.getMeanAzimuth();
+		const auto meanElevation = cluster.getMeanElevation();
+		const auto meanDistance = cluster.getMeanDistance();
+		const auto meanRadialSpeed = cluster.getMeanRadialSpeed();
+		uint32_t radialSpeedSamples = 0;
 
 		for (const auto pointInCluster : cluster.indices) {
-			clusterAabb.expand(xyzInputHost->at(pointInCluster));
+			clusterStats.aabb.expand(xyzInputHost->at(pointInCluster));
+			clusterStats.azimuthStd += std::pow(azimuthInputHost->at(pointInCluster) - meanAzimuth, 2.0f);
+			clusterStats.elevationStd += std::pow(elevationInputHost->at(pointInCluster) - meanElevation, 2.0f);
+			clusterStats.distanceStd += std::pow(distanceInputHost->at(pointInCluster) - meanDistance, 2.0f);
+			if (const auto radialSpeed = radialSpeedInputHost->at(pointInCluster); !std::isnan(radialSpeed)) {
+				clusterStats.radialSpeedStd += std::pow(radialSpeed - meanRadialSpeed, 2.0f);
+				++radialSpeedSamples;
+			}
+
 			std::complex<float> BU = {outBUBRFactorHost->at(pointInCluster)[0].real(),
 			                          outBUBRFactorHost->at(pointInCluster)[0].imag()};
 			std::complex<float> BR = {outBUBRFactorHost->at(pointInCluster)[1].real(),
@@ -166,6 +185,16 @@ void RadarPostprocessPointsNode::enqueueExecImpl()
 			                              outBUBRFactorHost->at(pointInCluster)[2].imag()};
 			AU += BU * factor;
 			AR += BR * factor;
+		}
+
+		if (!cluster.indices.empty()) {
+			clusterStats.azimuthStd = std::sqrt(clusterStats.azimuthStd / static_cast<float>(cluster.indices.size()));
+			clusterStats.elevationStd = std::sqrt(clusterStats.elevationStd / static_cast<float>(cluster.indices.size()));
+			clusterStats.distanceStd = std::sqrt(clusterStats.distanceStd / static_cast<float>(cluster.indices.size()));
+		}
+
+		if (radialSpeedSamples > 0) {
+			clusterStats.radialSpeedStd = std::sqrt(clusterStats.radialSpeedStd / static_cast<float>(radialSpeedSamples));
 		}
 
 		// https://en.wikipedia.org/wiki/Radar_cross_section#Formulation
@@ -269,6 +298,16 @@ RadarPostprocessPointsNode::RadarCluster::RadarCluster(Field<RAY_IDX_U32>::type 
 	minMaxAzimuth = {azimuth, azimuth};
 	minMaxRadialSpeed = {radialSpeed, radialSpeed};
 	minMaxElevation = {elevation, elevation};
+
+	sumOfDistances = distance;
+	sumOfAzimuths = azimuth;
+	sumOfElevations = elevation;
+
+	// This is not necessary for minMaxRadialSpeed, because adding and merging points handles that case.
+	if (!std::isnan(radialSpeed)) {
+		sumOfRadialSpeeds = radialSpeed;
+		radialSpeedSamples = 1;
+	}
 }
 
 void RadarPostprocessPointsNode::RadarCluster::addPoint(Field<RAY_IDX_U32>::type index, float distance, float azimuth,
@@ -295,6 +334,17 @@ void RadarPostprocessPointsNode::RadarCluster::addPoint(Field<RAY_IDX_U32>::type
 
 	minMaxElevation[0] = std::min(minMaxElevation[0], elevation);
 	minMaxElevation[1] = std::max(minMaxElevation[1], elevation);
+
+	sumOfDistances += distance;
+	sumOfAzimuths += azimuth;
+	sumOfElevations += elevation;
+
+	// Check comment above for more details. Radial speed can have nan values and this may result in lower number of samples
+	// included in sumOfRadialSpeeds (compared to other sums). For this reason, additional counter is necessary.
+	if (!std::isnan(radialSpeed)) {
+		sumOfRadialSpeeds += radialSpeed;
+		++radialSpeedSamples;
+	}
 }
 
 inline bool RadarPostprocessPointsNode::RadarCluster::isCandidate(float distance, float azimuth, float radialSpeed,
@@ -372,6 +422,11 @@ void RadarPostprocessPointsNode::RadarCluster::takeIndicesFrom(RadarCluster&& ot
 	minMaxElevation[0] = std::min(minMaxElevation[0], other.minMaxElevation[0]);
 	minMaxElevation[1] = std::max(minMaxElevation[1], other.minMaxElevation[1]);
 
+	sumOfDistances += other.sumOfDistances;
+	sumOfAzimuths += other.sumOfAzimuths;
+	sumOfRadialSpeeds += other.sumOfRadialSpeeds;
+	sumOfElevations += other.sumOfElevations;
+
 	// Move indices
 	std::size_t n = indices.size();
 	indices.resize(indices.size() + other.indices.size());
@@ -395,4 +450,28 @@ Field<RAY_IDX_U32>::type RadarPostprocessPointsNode::RadarCluster::findDirection
 		}
 	}
 	return minIndex;
+}
+
+Field<DISTANCE_F32>::type RadarPostprocessPointsNode::RadarCluster::getMeanDistance() const
+{
+	return sumOfDistances / static_cast<Field<DISTANCE_F32>::type>(indices.size());
+}
+
+Field<AZIMUTH_F32>::type RadarPostprocessPointsNode::RadarCluster::getMeanAzimuth() const
+{
+	return sumOfAzimuths / static_cast<Field<AZIMUTH_F32>::type>(indices.size());
+}
+
+Field<RADIAL_SPEED_F32>::type RadarPostprocessPointsNode::RadarCluster::getMeanRadialSpeed() const
+{
+	// Returning mean radial speed is the only case when number of samples may be 0. This is explained in RadarCluster constructor.
+	if (radialSpeedSamples == 0) {
+		return static_cast<Field<RADIAL_SPEED_F32>::type>(0);
+	}
+	return sumOfRadialSpeeds / static_cast<Field<RADIAL_SPEED_F32>::type>(radialSpeedSamples);
+}
+
+Field<ELEVATION_F32>::type RadarPostprocessPointsNode::RadarCluster::getMeanElevation() const
+{
+	return sumOfElevations / static_cast<Field<ELEVATION_F32>::type>(indices.size());
 }

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -61,10 +61,12 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 
 	// TODO(Pawel): Reconsider approach below.
 	// At this moment, I would like to check input this way, because it will keep RadarTrackObjectsNode testable without
-	// an input being RadarPostprocessPointsNode. If I have nullptr here, I simply do not process bounding boxes for detections.
+	// an input being RadarPostprocessPointsNode. If I have nullptr here, I simply do not process bounding boxes for detections clusters.
+	// Cluster stats are passed further as is.
 	auto radarPostprocessPointsNode = std::dynamic_pointer_cast<RadarPostprocessPointsNode>(input);
-	const auto detectionAabbs = radarPostprocessPointsNode ? radarPostprocessPointsNode->getClusterAabbs() :
-	                                                         std::vector<Aabb3Df>(input->getPointCount());
+	const auto clustersStats = radarPostprocessPointsNode ?
+	                               radarPostprocessPointsNode->getClustersStats() :
+	                               std::vector<RadarPostprocessPointsNode::ClusterStats>(input->getPointCount());
 
 	// Top level in this list is for objects. Bottom level is for detections that belong to specific objects. Below is an initialization of a helper
 	// structure for region growing, which starts with a while-loop.
@@ -123,9 +125,11 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 		for (const auto detectionIndex : separateObjectIndices) {
 			++entityIdHist[entityIdHostPtr->at(detectionIndex)];
 			objectBounds.position += xyzHostPtr->at(detectionIndex);
-			objectBounds.aabb += detectionAabbs[detectionIndex];
+			objectBounds.aabb += clustersStats[detectionIndex].aabb;
 			objectBounds.relVelocity += velocityRelHostPtr->at(detectionIndex);
 			objectBounds.absVelocity += velocityAbsHostPtr->at(detectionIndex);
+
+			// I need STD values -> these have to be calculated in RadarPostprocessPointsNode and propagated like getClusterAabbs().
 		}
 		// Most common detection entity id is assigned as object id.
 		int maxIdCount = -1;

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -133,7 +133,6 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 			objectBounds.absVelocity += velocityAbsHostPtr->at(detectionIndex);
 			objectBounds.detectionIndices.push_back(detectionIndex);
 
-			// I need STD values -> these have to be calculated in RadarPostprocessPointsNode and propagated like getClusterAabbs().
 			auto& detectionState = detectionStates[detectionIndex];
 			detectionState.azimuth = azimuthHostPtr->at(detectionIndex);
 			detectionState.azimuthStd = clustersStats[detectionIndex].azimuthStd;

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -180,7 +180,7 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 		}
 
 		// objectState do not have a match in newly detected object positions and it was also on ObjectStatus::Predicted last frame -
-		// not this object is considered lost and is removed from object list. Also remove its ID to poll.
+		// now this object is considered lost and is removed from object list. Also remove its ID to poll.
 		objectIDPoll.push(objectState.id);
 		objectStateIt = objectStates.erase(objectStateIt);
 	}
@@ -341,7 +341,7 @@ void RadarTrackObjectsNode::updateOutputData()
 	for (const auto& objectState : objectStates) {
 		assert(objectState.id <= std::numeric_limits<Field<ENTITY_ID_I32>::type>::max());
 		xyzPtr[objectIndex] = objectState.position.getLastSample();
-		idPtr[objectIndex] = objectState.id;
+		idPtr[objectIndex] = static_cast<Field<ENTITY_ID_I32>::type>(objectState.id);
 		++objectIndex;
 	}
 

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -55,6 +55,7 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 	azimuthHostPtr->copyFrom(input->getFieldData(AZIMUTH_F32));
 	elevationHostPtr->copyFrom(input->getFieldData(ELEVATION_F32));
 	radialSpeedHostPtr->copyFrom(input->getFieldData(RADIAL_SPEED_F32));
+	rcsHostPtr->copyFrom(input->getFieldData(RCS_F32));
 	entityIdHostPtr->copyFrom(input->getFieldData(ENTITY_ID_I32));
 	velocityRelHostPtr->copyFrom(input->getFieldData(RELATIVE_VELOCITY_VEC3_F32));
 	velocityAbsHostPtr->copyFrom(input->getFieldData(ABSOLUTE_VELOCITY_VEC3_F32));
@@ -67,6 +68,7 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 	const auto clustersStats = radarPostprocessPointsNode ?
 	                               radarPostprocessPointsNode->getClustersStats() :
 	                               std::vector<RadarPostprocessPointsNode::ClusterStats>(input->getPointCount());
+	assert(clustersStats.size() == input->getPointCount());
 
 	// Top level in this list is for objects. Bottom level is for detections that belong to specific objects. Below is an initialization of a helper
 	// structure for region growing, which starts with a while-loop.
@@ -117,7 +119,8 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 		}
 	}
 
-	// Calculate positions of objects detected in current frame.
+	// Calculate positions of objects detected in current frame. Additionally, calculate detection states.
+	detectionStates.resize(input->getPointCount());
 	std::list<ObjectBounds> newObjectBounds;
 	for (const auto& separateObjectIndices : objectIndices) {
 		auto& objectBounds = newObjectBounds.emplace_back();
@@ -128,8 +131,20 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 			objectBounds.aabb += clustersStats[detectionIndex].aabb;
 			objectBounds.relVelocity += velocityRelHostPtr->at(detectionIndex);
 			objectBounds.absVelocity += velocityAbsHostPtr->at(detectionIndex);
+			objectBounds.detectionIndices.push_back(detectionIndex);
 
 			// I need STD values -> these have to be calculated in RadarPostprocessPointsNode and propagated like getClusterAabbs().
+			auto& detectionState = detectionStates[detectionIndex];
+			detectionState.azimuth = azimuthHostPtr->at(detectionIndex);
+			detectionState.azimuthStd = clustersStats[detectionIndex].azimuthStd;
+			detectionState.elevation = elevationHostPtr->at(detectionIndex);
+			detectionState.elevationStd = clustersStats[detectionIndex].elevationStd;
+			detectionState.distance = distanceHostPtr->at(detectionIndex);
+			detectionState.distanceStd = clustersStats[detectionIndex].distanceStd;
+			detectionState.radialSpeed = radialSpeedHostPtr->at(detectionIndex);
+			detectionState.radialSpeedStd = clustersStats[detectionIndex].radialSpeedStd;
+			detectionState.rcs = rcsHostPtr->at(detectionIndex);
+			detectionState.detectionId = static_cast<uint32_t>(detectionIndex);
 		}
 		// Most common detection entity id is assigned as object id.
 		int maxIdCount = -1;
@@ -164,6 +179,9 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 		    (predictedPosition - closestObject.position).length() < maxMatchingDistance) {
 			updateObjectState(objectState, closestObject.position, closestObject.aabb, ObjectStatus::Measured, currentTime,
 			                  deltaTime, closestObject.absVelocity, closestObject.relVelocity);
+			for (const auto detectionIndex : closestObject.detectionIndices) {
+				detectionStates[detectionIndex].objectId = objectState.id;
+			}
 			newObjectBounds.erase(closestObjectIt);
 			++objectStateIt;
 			continue;
@@ -187,7 +205,10 @@ void RadarTrackObjectsNode::enqueueExecImpl()
 
 	// All newly detected object position that do not have a match in previous frame - create new object state.
 	for (const auto& newObject : newObjectBounds) {
-		createObjectState(newObject, currentTime);
+		const auto& newObjectState = createObjectState(newObject, currentTime);
+		for (const auto detectionIndex : newObject.detectionIndices) {
+			detectionStates[detectionIndex].objectId = newObjectState.id;
+		}
 	}
 
 	updateOutputData();
@@ -200,6 +221,7 @@ std::vector<rgl_field_t> RadarTrackObjectsNode::getRequiredFieldList() const
 	        AZIMUTH_F32,
 	        ELEVATION_F32,
 	        RADIAL_SPEED_F32,
+	        RCS_F32,
 	        ENTITY_ID_I32,
 	        RELATIVE_VELOCITY_VEC3_F32,
 	        ABSOLUTE_VELOCITY_VEC3_F32};
@@ -244,7 +266,7 @@ void RadarTrackObjectsNode::parseEntityIdToClassProbability(Field<ENTITY_ID_I32>
 	}
 }
 
-void RadarTrackObjectsNode::createObjectState(const ObjectBounds& objectBounds, double currentTimeMs)
+const RadarTrackObjectsNode::ObjectState& RadarTrackObjectsNode::createObjectState(const ObjectBounds& objectBounds, double currentTimeMs)
 {
 	auto& objectState = objectStates.emplace_back();
 	if (objectIDPoll.empty()) {
@@ -278,6 +300,7 @@ void RadarTrackObjectsNode::createObjectState(const ObjectBounds& objectBounds, 
 	objectState.width.addSample((-objectBounds.aabb.maxCorner().x()) - (-objectBounds.aabb.minCorner().x()));
 
 	objectState.positionSensorFrame = lookAtSensorFrameTransform * objectState.position.getLastSample();
+	return objectState;
 }
 
 void RadarTrackObjectsNode::updateObjectState(ObjectState& objectState, const Vec3f& updatedPosition,


### PR DESCRIPTION
This PR adds cluster statistics (std for azimuth, elevation, distance, radial speed) to RadarPostprocessPointsNode. This statistics is added to previously available cluster AABBs, and exposed through Node API. This data is consumed further in RadarTrackObjectsNode in order to calculate detection states.