### PR TITLE
Add ROS 2 RadarTracks publishing

### DIFF
--- a/extensions/ros2/CMakeLists.txt
+++ b/extensions/ros2/CMakeLists.txt
@@ -16,6 +16,7 @@ target_sources(RobotecGPULidar PRIVATE
     src/graph/Ros2PublishPointsNode.cpp
     src/graph/Ros2PublishPointVelocityMarkersNode.cpp
     src/graph/Ros2PublishRadarScanNode.cpp
+    src/graph/Ros2PublishRadarTracksNode.cpp
 )
 
 target_include_directories(RobotecGPULidar PUBLIC

--- a/extensions/ros2/include/rgl/api/extensions/ros2.h
+++ b/extensions/ros2/include/rgl/api/extensions/ros2.h
@@ -120,11 +120,13 @@ RGL_API rgl_status_t rgl_node_publish_ros2_radarscan(rgl_node_t* node, const cha
  * @param qos_durability QoS durability policy.
  * @param qos_history QoS history policy.
  * @param qos_history_depth QoS history depth. If history policy is KEEP_ALL, depth is ignored but must always be non-negative.
+ * @param changeOfBasisTf Pointer to rgl_mat3x4f representing coordinate frame basis change to apply before publishing (e.g., Engine to ROS2).
  */
 RGL_API rgl_status_t rgl_node_publish_ros2_radartracks(rgl_node_t* node, const char* topic_name, const char* frame_id,
-                                                     rgl_qos_policy_reliability_t qos_reliability,
-                                                     rgl_qos_policy_durability_t qos_durability,
-                                                     rgl_qos_policy_history_t qos_history, int32_t qos_history_depth);
+                                                       rgl_qos_policy_reliability_t qos_reliability,
+                                                       rgl_qos_policy_durability_t qos_durability,
+                                                       rgl_qos_policy_history_t qos_history, int32_t qos_history_depth,
+                                                       const rgl_mat3x4f* changeOfBasisTf);
 
 /**
  * Modifies ROS 2 publishing RGL node to use Agnocast.

--- a/extensions/ros2/include/rgl/api/extensions/ros2.h
+++ b/extensions/ros2/include/rgl/api/extensions/ros2.h
@@ -108,6 +108,25 @@ RGL_API rgl_status_t rgl_node_publish_ros2_radarscan(rgl_node_t* node, const cha
                                                      rgl_qos_policy_history_t qos_history, int32_t qos_history_depth);
 
 /**
+ * Creates or modifies Ros2PublishRadarTracksNode.
+ * The node publishes a RadarTracks message to the ROS2 topic using specified Quality of Service settings.
+ * The message header stamp gets time from the raytraced scene. If the scene has no time, header will get the actual time.
+ * Graph input: RadarTrackObjectsNode
+ * Graph output: point cloud
+ * @param node If (*node) == nullptr, a new node will be created. Otherwise, (*node) will be modified.
+ * @param topic_name Topic name to publish on.
+ * @param frame_id Frame this data is associated with.
+ * @param qos_reliability QoS reliability policy.
+ * @param qos_durability QoS durability policy.
+ * @param qos_history QoS history policy.
+ * @param qos_history_depth QoS history depth. If history policy is KEEP_ALL, depth is ignored but must always be non-negative.
+ */
+RGL_API rgl_status_t rgl_node_publish_ros2_radartracks(rgl_node_t* node, const char* topic_name, const char* frame_id,
+                                                     rgl_qos_policy_reliability_t qos_reliability,
+                                                     rgl_qos_policy_durability_t qos_durability,
+                                                     rgl_qos_policy_history_t qos_history, int32_t qos_history_depth);
+
+/**
  * Modifies ROS 2 publishing RGL node to use Agnocast.
  * Agnocast is novel True Zero-Copy middleware coexisting with ROS 2 developed by TierIV.
  * See: https://github.com/orgs/autowarefoundation/discussions/5835

--- a/extensions/ros2/src/api/apiRos2.cpp
+++ b/extensions/ros2/src/api/apiRos2.cpp
@@ -126,6 +126,40 @@ void TapeRos2::tape_node_publish_ros2_radarscan(const YAML::Node& yamlNode, Play
 	state.nodes.insert(std::make_pair(nodeId, node));
 }
 
+RGL_API rgl_status_t rgl_node_publish_ros2_radartracks(rgl_node_t* node, const char* topic_name, const char* frame_id,
+                                                       rgl_qos_policy_reliability_t qos_reliability,
+                                                       rgl_qos_policy_durability_t qos_durability,
+                                                       rgl_qos_policy_history_t qos_history, int32_t qos_history_depth)
+{
+	auto status = rglSafeCall([&]() {
+		RGL_DEBUG(
+		    "tape_node_publish_ros2_radartracks(node={}, topic_name={}, frame_id={}, qos_reliability={}, qos_durability={}, "
+		    "qos_history={}, qos_history_depth={})",
+		    repr(node), topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth);
+		CHECK_ARG(topic_name != nullptr);
+		CHECK_ARG(topic_name[0] != '\0');
+		CHECK_ARG(frame_id != nullptr);
+		CHECK_ARG(frame_id[0] != '\0');
+		CHECK_ARG(qos_history_depth >= 0);
+
+		createOrUpdateNode<Ros2PublishRadarTracksNode>(node, topic_name, frame_id, qos_reliability, qos_durability, qos_history,
+		                                               qos_history_depth);
+	});
+	TAPE_HOOK(node, topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth);
+	return status;
+}
+
+void TapeRos2::tape_node_publish_ros2_radartracks(const YAML::Node& yamlNode, PlaybackState& state)
+{
+	auto nodeId = yamlNode[0].as<TapeAPIObjectID>();
+	rgl_node_t node = state.nodes.contains(nodeId) ? state.nodes[nodeId] : nullptr;
+	rgl_node_publish_ros2_radartracks(&node, yamlNode[1].as<std::string>().c_str(), yamlNode[2].as<std::string>().c_str(),
+	                                  (rgl_qos_policy_reliability_t) yamlNode[3].as<int>(),
+	                                  (rgl_qos_policy_durability_t) yamlNode[4].as<int>(),
+	                                  (rgl_qos_policy_history_t) yamlNode[5].as<int>(), yamlNode[6].as<int32_t>());
+	state.nodes.insert(std::make_pair(nodeId, node));
+}
+
 RGL_API rgl_status_t rgl_node_configure_agnocast(rgl_node_t node, bool enable)
 {
 	auto status = rglSafeCall([&]() {

--- a/extensions/ros2/src/api/apiRos2.cpp
+++ b/extensions/ros2/src/api/apiRos2.cpp
@@ -129,23 +129,26 @@ void TapeRos2::tape_node_publish_ros2_radarscan(const YAML::Node& yamlNode, Play
 RGL_API rgl_status_t rgl_node_publish_ros2_radartracks(rgl_node_t* node, const char* topic_name, const char* frame_id,
                                                        rgl_qos_policy_reliability_t qos_reliability,
                                                        rgl_qos_policy_durability_t qos_durability,
-                                                       rgl_qos_policy_history_t qos_history, int32_t qos_history_depth)
+                                                       rgl_qos_policy_history_t qos_history, int32_t qos_history_depth,
+                                                       const rgl_mat3x4f* changeOfBasisTf)
 {
 	auto status = rglSafeCall([&]() {
 		RGL_DEBUG(
 		    "tape_node_publish_ros2_radartracks(node={}, topic_name={}, frame_id={}, qos_reliability={}, qos_durability={}, "
-		    "qos_history={}, qos_history_depth={})",
-		    repr(node), topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth);
+		    "qos_history={}, qos_history_depth={}, changeOfBasisTf={})",
+		    repr(node), topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth,
+		    repr(changeOfBasisTf, 1));
 		CHECK_ARG(topic_name != nullptr);
 		CHECK_ARG(topic_name[0] != '\0');
 		CHECK_ARG(frame_id != nullptr);
 		CHECK_ARG(frame_id[0] != '\0');
 		CHECK_ARG(qos_history_depth >= 0);
+		CHECK_ARG(changeOfBasisTf != nullptr);
 
 		createOrUpdateNode<Ros2PublishRadarTracksNode>(node, topic_name, frame_id, qos_reliability, qos_durability, qos_history,
-		                                               qos_history_depth);
+		                                               qos_history_depth, Mat3x4f::fromRGL(*changeOfBasisTf));
 	});
-	TAPE_HOOK(node, topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth);
+	TAPE_HOOK(node, topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth, changeOfBasisTf);
 	return status;
 }
 
@@ -156,7 +159,8 @@ void TapeRos2::tape_node_publish_ros2_radartracks(const YAML::Node& yamlNode, Pl
 	rgl_node_publish_ros2_radartracks(&node, yamlNode[1].as<std::string>().c_str(), yamlNode[2].as<std::string>().c_str(),
 	                                  (rgl_qos_policy_reliability_t) yamlNode[3].as<int>(),
 	                                  (rgl_qos_policy_durability_t) yamlNode[4].as<int>(),
-	                                  (rgl_qos_policy_history_t) yamlNode[5].as<int>(), yamlNode[6].as<int32_t>());
+	                                  (rgl_qos_policy_history_t) yamlNode[5].as<int>(), yamlNode[6].as<int32_t>(),
+	                                  state.getPtr<const rgl_mat3x4f>(yamlNode[7]));
 	state.nodes.insert(std::make_pair(nodeId, node));
 }
 

--- a/extensions/ros2/src/api/apiRos2.cpp
+++ b/extensions/ros2/src/api/apiRos2.cpp
@@ -98,10 +98,9 @@ RGL_API rgl_status_t rgl_node_publish_ros2_radarscan(rgl_node_t* node, const cha
                                                      rgl_qos_policy_history_t qos_history, int32_t qos_history_depth)
 {
 	auto status = rglSafeCall([&]() {
-		RGL_DEBUG(
-		    "tape_node_publish_ros2_radarscan(node={}, topic_name={}, frame_id={}, qos_reliability={}, qos_durability={}, "
-		    "qos_history={}, qos_history_depth={})",
-		    repr(node), topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth);
+		RGL_DEBUG("rgl_node_publish_ros2_radarscan(node={}, topic_name={}, frame_id={}, qos_reliability={}, qos_durability={}, "
+		          "qos_history={}, qos_history_depth={})",
+		          repr(node), topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth);
 		CHECK_ARG(topic_name != nullptr);
 		CHECK_ARG(topic_name[0] != '\0');
 		CHECK_ARG(frame_id != nullptr);
@@ -134,7 +133,7 @@ RGL_API rgl_status_t rgl_node_publish_ros2_radartracks(rgl_node_t* node, const c
 {
 	auto status = rglSafeCall([&]() {
 		RGL_DEBUG(
-		    "tape_node_publish_ros2_radartracks(node={}, topic_name={}, frame_id={}, qos_reliability={}, qos_durability={}, "
+		    "rgl_node_publish_ros2_radartracks(node={}, topic_name={}, frame_id={}, qos_reliability={}, qos_durability={}, "
 		    "qos_history={}, qos_history_depth={}, changeOfBasisTf={})",
 		    repr(node), topic_name, frame_id, qos_reliability, qos_durability, qos_history, qos_history_depth,
 		    repr(changeOfBasisTf, 1));

--- a/extensions/ros2/src/graph/NodesRos2.hpp
+++ b/extensions/ros2/src/graph/NodesRos2.hpp
@@ -193,14 +193,14 @@ private:
 
 	Mat3x4f changeOfBasisTf;
 
-	geometry_msgs::msg::Point ProcessReferencePoint(const geometry_msgs::msg::Point& referencePoint, float yaw, float length,
+	geometry_msgs::msg::Point processReferencePoint(const geometry_msgs::msg::Point& referencePoint, float yaw, float length,
 	                                                float width, int referenceIndex) const;
 
-	radar_msgs::msg::RadarTrack::_classification_type ProcessObjectProbabilities(
+	radar_msgs::msg::RadarTrack::_classification_type processObjectProbabilities(
 	    const RadarTrackObjectsNode::ClassificationProbabilities& probabilities) const;
 
 	template<typename TrackVecT>
-	TrackVecT ProcessObjectStat(const RunningStats<Vec3f>& objectStat) const
+	TrackVecT processObjectStat(const RunningStats<Vec3f>& objectStat) const
 	{
 		const auto& statRef = changeOfBasisTf.rotation() * objectStat.getLastSample();
 		TrackVecT trackStat{};
@@ -210,5 +210,5 @@ private:
 		return trackStat;
 	}
 
-	std::array<float, 6> ProcessObjectStatCov(const RunningStats<Vec3f>& objectStat) const;
+	std::array<float, 6> processObjectStatCov(const RunningStats<Vec3f>& objectStat) const;
 };

--- a/extensions/ros2/src/graph/NodesRos2.hpp
+++ b/extensions/ros2/src/graph/NodesRos2.hpp
@@ -193,6 +193,9 @@ private:
 	DeviceAsyncArray<char>::Ptr formattedData = DeviceAsyncArray<char>::create(arrayMgr);
 	GPUFieldDescBuilder fieldDescBuilder;
 
+	geometry_msgs::msg::Point ProcessReferencePoint(const geometry_msgs::msg::Point& referencePoint, float yaw, float length,
+	                                                float width, int referenceIndex) const;
+
 	radar_msgs::msg::RadarTrack::_classification_type ProcessObjectProbabilities(
 	    const RadarTrackObjectsNode::ClassificationProbabilities& probabilities) const;
 

--- a/extensions/ros2/src/graph/NodesRos2.hpp
+++ b/extensions/ros2/src/graph/NodesRos2.hpp
@@ -21,6 +21,7 @@
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 #include <radar_msgs/msg/radar_scan.hpp>
+#include <radar_msgs/msg/radar_tracks.hpp>
 
 #include <graph/Node.hpp>
 #include <graph/NodesCore.hpp>
@@ -162,6 +163,33 @@ struct Ros2PublishRadarScanNode : Ros2Node
 
 private:
 	using MessageT = radar_msgs::msg::RadarScan;
+
+	std::unique_ptr<MessagePublisher<MessageT>> messagePublisher;
+	std::string frameId{};
+
+	DeviceAsyncArray<char>::Ptr formattedData = DeviceAsyncArray<char>::create(arrayMgr);
+	GPUFieldDescBuilder fieldDescBuilder;
+};
+
+struct Ros2PublishRadarTracksNode : Ros2Node
+{
+	void setParameters(const char* topicName, const char* messageFrameId, rgl_qos_policy_reliability_t qosReliability,
+	                   rgl_qos_policy_durability_t qosDurability, rgl_qos_policy_history_t qosHistory, int32_t qosHistoryDepth);
+	std::vector<rgl_field_t> getRequiredFieldList() const override
+	{
+		return {DISTANCE_F32, AZIMUTH_F32, ELEVATION_F32, RADIAL_SPEED_F32, /* placeholder for amplitude */ PADDING_32};
+	}
+
+	// Ros2Node
+	void ros2ValidateImpl() override;
+	void ros2EnqueueExecImpl() override;
+
+#if RGL_BUILD_AGNOCAST_EXTENSION
+	void configureAgnocastImpl(bool enable) override;
+#endif
+
+private:
+	using MessageT = radar_msgs::msg::RadarTracks;
 
 	std::unique_ptr<MessagePublisher<MessageT>> messagePublisher;
 	std::string frameId{};

--- a/extensions/ros2/src/graph/NodesRos2.hpp
+++ b/extensions/ros2/src/graph/NodesRos2.hpp
@@ -196,4 +196,20 @@ private:
 
 	DeviceAsyncArray<char>::Ptr formattedData = DeviceAsyncArray<char>::create(arrayMgr);
 	GPUFieldDescBuilder fieldDescBuilder;
+
+	radar_msgs::msg::RadarTrack::_classification_type ProcessObjectProbabilities(
+	    const RadarTrackObjectsNode::ClassificationProbabilities& probabilities) const;
+
+	template<typename TrackVecT>
+	TrackVecT ProcessObjectStat(const RunningStats<Vec3f>& objectStat) const
+	{
+		const auto& statRef = objectStat.getLastSample();
+		TrackVecT trackStat{};
+		trackStat.set__x(statRef.x());
+		trackStat.set__y(statRef.y());
+		trackStat.set__z(statRef.z());
+		return trackStat;
+	}
+
+	std::array<float, 6> ProcessObjectStatCov(const RunningStats<Vec3f>& objectStat) const;
 };

--- a/extensions/ros2/src/graph/NodesRos2.hpp
+++ b/extensions/ros2/src/graph/NodesRos2.hpp
@@ -175,10 +175,6 @@ struct Ros2PublishRadarTracksNode : Ros2Node
 {
 	void setParameters(const char* topicName, const char* messageFrameId, rgl_qos_policy_reliability_t qosReliability,
 	                   rgl_qos_policy_durability_t qosDurability, rgl_qos_policy_history_t qosHistory, int32_t qosHistoryDepth);
-	std::vector<rgl_field_t> getRequiredFieldList() const override
-	{
-		return {DISTANCE_F32, AZIMUTH_F32, ELEVATION_F32, RADIAL_SPEED_F32, /* placeholder for amplitude */ PADDING_32};
-	}
 
 	// Ros2Node
 	void ros2ValidateImpl() override;

--- a/extensions/ros2/src/graph/NodesRos2.hpp
+++ b/extensions/ros2/src/graph/NodesRos2.hpp
@@ -174,7 +174,8 @@ private:
 struct Ros2PublishRadarTracksNode : Ros2Node
 {
 	void setParameters(const char* topicName, const char* messageFrameId, rgl_qos_policy_reliability_t qosReliability,
-	                   rgl_qos_policy_durability_t qosDurability, rgl_qos_policy_history_t qosHistory, int32_t qosHistoryDepth);
+	                   rgl_qos_policy_durability_t qosDurability, rgl_qos_policy_history_t qosHistory, int32_t qosHistoryDepth,
+	                   const Mat3x4f& changeOfBasisTf_);
 
 	// Ros2Node
 	void ros2ValidateImpl() override;
@@ -190,8 +191,7 @@ private:
 	std::unique_ptr<MessagePublisher<MessageT>> messagePublisher;
 	std::string frameId{};
 
-	DeviceAsyncArray<char>::Ptr formattedData = DeviceAsyncArray<char>::create(arrayMgr);
-	GPUFieldDescBuilder fieldDescBuilder;
+	Mat3x4f changeOfBasisTf;
 
 	geometry_msgs::msg::Point ProcessReferencePoint(const geometry_msgs::msg::Point& referencePoint, float yaw, float length,
 	                                                float width, int referenceIndex) const;
@@ -202,7 +202,7 @@ private:
 	template<typename TrackVecT>
 	TrackVecT ProcessObjectStat(const RunningStats<Vec3f>& objectStat) const
 	{
-		const auto& statRef = objectStat.getLastSample();
+		const auto& statRef = changeOfBasisTf.rotation() * objectStat.getLastSample();
 		TrackVecT trackStat{};
 		trackStat.set__x(statRef.x());
 		trackStat.set__y(statRef.y());

--- a/extensions/ros2/src/graph/Ros2PublishRadarScanNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarScanNode.cpp
@@ -31,7 +31,7 @@ void Ros2PublishRadarScanNode::setParameters(const char* topicName, const char* 
 void Ros2PublishRadarScanNode::ros2ValidateImpl()
 {
 	if (input->getHeight() != 1) {
-		throw InvalidPipeline("ROS2 radar publish supports unorganized pointclouds only");
+		throw InvalidPipeline("ROS2 radar scan publish supports unorganized pointclouds only");
 	}
 }
 

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -76,13 +76,13 @@ void Ros2PublishRadarTracksNode::ros2EnqueueExecImpl()
 		radarTrack.velocity_covariance = ProcessObjectStatCov(objectState.relVelocity);
 		radarTrack.acceleration_covariance = ProcessObjectStatCov(objectState.relAccel);
 
-		constexpr float invalidCovariance = 1e6f;
-		radarTrack.size_covariance[0] = invalidCovariance;
-		radarTrack.size_covariance[1] = 0.0f;
+		// Height (Z coordinate) is not available in objectState - related covariances are set to 0.
+		radarTrack.size_covariance[0] = objectState.length.getVariance();
+		radarTrack.size_covariance[1] = objectState.length.getStdDev() * objectState.width.getStdDev();
 		radarTrack.size_covariance[2] = 0.0f;
-		radarTrack.size_covariance[3] = invalidCovariance;
+		radarTrack.size_covariance[3] = objectState.width.getVariance();
 		radarTrack.size_covariance[4] = 0.0f;
-		radarTrack.size_covariance[5] = invalidCovariance;
+		radarTrack.size_covariance[5] = 0.0f;
 
 		++i;
 	}
@@ -180,13 +180,13 @@ radar_msgs::msg::RadarTrack::_classification_type Ros2PublishRadarTracksNode::Pr
 
 std::array<float, 6> Ros2PublishRadarTracksNode::ProcessObjectStatCov(const RunningStats<Vec3f>& objectStat) const
 {
-	const auto& statStd = objectStat.getStdDev();
+	const auto& statVariance = objectStat.getVariance();
 	std::array<float, 6> trackStatCov{};
-	trackStatCov[0] = statStd.x() * statStd.x();
+	trackStatCov[0] = statVariance.x();
 	trackStatCov[1] = objectStat.getCovarianceXY();
-	trackStatCov[2] = 0.0f;
-	trackStatCov[3] = statStd.y() * statStd.y();
-	trackStatCov[4] = 0.0f;
-	trackStatCov[5] = statStd.z() * statStd.z();
+	trackStatCov[2] = objectStat.getCovarianceZX();
+	trackStatCov[3] = statVariance.y();
+	trackStatCov[4] = objectStat.getCovarianceYZ();
+	trackStatCov[5] = statVariance.z();
 	return trackStatCov;
 }

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -53,63 +53,24 @@ void Ros2PublishRadarTracksNode::ros2EnqueueExecImpl()
 	int i = 0;
 	for (const auto& objectState : objectStates) {
 		auto& radarTrack = ros2Message.tracks[i];
-		radarTrack.uuid.set__uuid({});
 
-		{
-			const auto& objectPosition = objectState.position.getLastSample();
-			radarTrack.position.set__x(objectPosition.x());
-			radarTrack.position.set__y(objectPosition.y());
-			radarTrack.position.set__z(objectPosition.z());
-		}
-		{
-			const auto& objectVelocity = objectState.relVelocity.getLastSample();
-			radarTrack.velocity.set__x(objectVelocity.x());
-			radarTrack.velocity.set__y(objectVelocity.y());
-			radarTrack.velocity.set__z(objectVelocity.z());
-		}
-		{
-			const auto objectAcceleration = objectState.relAccel.getLastSample();
-			radarTrack.acceleration.set__x(objectAcceleration.x());
-			radarTrack.acceleration.set__y(objectAcceleration.y());
-			radarTrack.acceleration.set__z(objectAcceleration.z());
-		}
-		{
-			const Vec3f size = {};
-			radarTrack.size.set__x(size.x());
-			radarTrack.size.set__y(size.y());
-			radarTrack.size.set__z(size.z());
-		}
+		assert(sizeof(objectState.id) == 4); // Be sure that uuid matches object ID.
+		radarTrack.uuid.uuid[0] = static_cast<uint8_t>(objectState.id & 0xff);
+		radarTrack.uuid.uuid[1] = static_cast<uint8_t>((objectState.id >> 8) & 0xff);
+		radarTrack.uuid.uuid[2] = static_cast<uint8_t>((objectState.id >> 16) & 0xff);
+		radarTrack.uuid.uuid[3] = static_cast<uint8_t>((objectState.id >> 24) & 0xff);
 
-		radarTrack.classification = radar_msgs::msg::RadarTrack::
-		    NO_CLASSIFICATION; // TODO(Pawel): Decide if we do not want to classify it based on e.g. velocity (STATIC or DYNAMIC object)
+		radarTrack.position = ProcessObjectStat<decltype(radarTrack.position)>(objectState.position);
+		radarTrack.velocity = ProcessObjectStat<decltype(radarTrack.velocity)>(objectState.absVelocity);
+		radarTrack.acceleration = ProcessObjectStat<decltype(radarTrack.acceleration)>(objectState.absAccel);
+		//radarTrack.size = ProcessObjectStat<decltype(radarTrack.size)>(objectState.dimensions);
 
-		//radarTrack.position_covariance[0] = objectState.position.getCovarianceXX();
-		radarTrack.position_covariance[1] = objectState.position.getCovarianceXY();
-		radarTrack.position_covariance[2] = objectState.position.getCovarianceZX();
-		//radarTrack.position_covariance[3] = objectState.position.getCovarianceYY();
-		radarTrack.position_covariance[4] = objectState.position.getCovarianceYZ();
-		//radarTrack.position_covariance[5] = objectState.position.getCovarianceZZ();
+		radarTrack.classification = ProcessObjectProbabilities(objectState.classificationProbabilities);
 
-		//radarTrack.velocity_covariance[0] = objectState.relVelocity.getCovarianceXX();
-		radarTrack.velocity_covariance[1] = objectState.relVelocity.getCovarianceXY();
-		radarTrack.velocity_covariance[2] = objectState.relVelocity.getCovarianceZX();
-		//radarTrack.velocity_covariance[3] = objectState.relVelocity.getCovarianceYY();
-		radarTrack.velocity_covariance[4] = objectState.relVelocity.getCovarianceYZ();
-		//radarTrack.velocity_covariance[5] = objectState.relVelocity.getCovarianceZZ();
-
-		//radarTrack.acceleration_covariance[0] = objectState.relAccel.getCovarianceXX();
-		radarTrack.acceleration_covariance[1] = objectState.relAccel.getCovarianceXY();
-		radarTrack.acceleration_covariance[2] = objectState.relAccel.getCovarianceZX();
-		//radarTrack.acceleration_covariance[3] = objectState.relAccel.getCovarianceYY();
-		radarTrack.acceleration_covariance[4] = objectState.relAccel.getCovarianceYZ();
-		//radarTrack.acceleration_covariance[5] = objectState.relAccel.getCovarianceZZ();
-
-		//radarTrack.size_covariance[0] = objectState.dimensions.getCovarianceXX();
-		//radarTrack.size_covariance[1] = objectState.dimensions.getCovarianceXY();
-		//radarTrack.size_covariance[2] = objectState.dimensions.getCovarianceZX();
-		//radarTrack.size_covariance[3] = objectState.dimensions.getCovarianceYY();
-		//radarTrack.size_covariance[4] = objectState.dimensions.getCovarianceYZ();
-		//radarTrack.size_covariance[5] = objectState.dimensions.getCovarianceZZ();
+		radarTrack.position_covariance = ProcessObjectStatCov(objectState.position);
+		radarTrack.velocity_covariance = ProcessObjectStatCov(objectState.relVelocity);
+		radarTrack.acceleration_covariance = ProcessObjectStatCov(objectState.relAccel);
+		//radarTrack.size_covariance = ProcessObjectStatCov(objectState.dimensions);
 
 		++i;
 	}
@@ -136,3 +97,53 @@ void Ros2PublishRadarTracksNode::configureAgnocastImpl(bool enable)
 	    ros2InitGuard->getNode(), messagePublisher->getTopicName(), messagePublisher->getQos());
 }
 #endif
+
+radar_msgs::msg::RadarTrack::_classification_type Ros2PublishRadarTracksNode::ProcessObjectProbabilities(
+    const RadarTrackObjectsNode::ClassificationProbabilities& probabilities) const
+{
+	constexpr int16_t unknownID = 32000;
+	constexpr int16_t carID = 32001;
+	constexpr int16_t truckID = 32002;
+	constexpr int16_t motorcycleID = 32005;
+	constexpr int16_t bicycleID = 32006;
+	constexpr int16_t pedestrianID = 32007;
+
+	auto maxScore = probabilities.classUnknown;
+	radar_msgs::msg::RadarTrack::_classification_type outputClass = unknownID;
+
+	if (probabilities.classCar > maxScore) {
+		maxScore = probabilities.classCar;
+		outputClass = carID;
+	}
+	if (probabilities.classTruck > maxScore) {
+		maxScore = probabilities.classTruck;
+		outputClass = truckID;
+	}
+	if (probabilities.classMotorcycle > maxScore) {
+		maxScore = probabilities.classMotorcycle;
+		outputClass = motorcycleID;
+	}
+	if (probabilities.classBicycle > maxScore) {
+		maxScore = probabilities.classBicycle;
+		outputClass = bicycleID;
+	}
+	if (probabilities.classPedestrian > maxScore) {
+		maxScore = probabilities.classPedestrian;
+		outputClass = pedestrianID;
+	}
+
+	return outputClass;
+}
+
+std::array<float, 6> Ros2PublishRadarTracksNode::ProcessObjectStatCov(const RunningStats<Vec3f>& objectStat) const
+{
+	const auto& statStd = objectStat.getStdDev();
+	std::array<float, 6> trackStatCov{};
+	trackStatCov[0] = statStd.x() * statStd.x();
+	trackStatCov[1] = objectStat.getCovarianceXY();
+	trackStatCov[2] = 0.0f;
+	trackStatCov[3] = statStd.y() * statStd.y();
+	trackStatCov[4] = 0.0f;
+	trackStatCov[5] = statStd.z() * statStd.z();
+	return trackStatCov;
+}

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -18,9 +18,10 @@
 void Ros2PublishRadarTracksNode::setParameters(const char* topicName, const char* messageFrameId,
                                                rgl_qos_policy_reliability_t qosReliability,
                                                rgl_qos_policy_durability_t qosDurability, rgl_qos_policy_history_t qosHistory,
-                                               int32_t qosHistoryDepth)
+                                               int32_t qosHistoryDepth, const Mat3x4f& changeOfBasisTf_)
 {
 	frameId = messageFrameId;
+	changeOfBasisTf = changeOfBasisTf_;
 	auto qos = rclcpp::QoS(qosHistoryDepth);
 	qos.reliability(static_cast<rmw_qos_reliability_policy_t>(qosReliability));
 	qos.durability(static_cast<rmw_qos_durability_policy_t>(qosDurability));
@@ -60,7 +61,10 @@ void Ros2PublishRadarTracksNode::ros2EnqueueExecImpl()
 		radarTrack.uuid.uuid[3] = static_cast<uint8_t>((objectState.id >> 24) & 0xff);
 
 		constexpr int signalUnfilled = 255; // According to documentation.
-		radarTrack.position = ProcessObjectStat<decltype(radarTrack.position)>(objectState.position);
+		const auto position = changeOfBasisTf.rotation() * objectState.positionSensorFrame;
+		radarTrack.position.x = position.x();
+		radarTrack.position.y = position.y();
+		radarTrack.position.z = position.z();
 		radarTrack.position = ProcessReferencePoint(radarTrack.position, objectState.orientation.getLastSample(),
 		                                            objectState.length.getMean(), objectState.width.getMean(), signalUnfilled);
 		radarTrack.velocity = ProcessObjectStat<decltype(radarTrack.velocity)>(objectState.absVelocity);
@@ -179,13 +183,15 @@ radar_msgs::msg::RadarTrack::_classification_type Ros2PublishRadarTracksNode::Pr
 
 std::array<float, 6> Ros2PublishRadarTracksNode::ProcessObjectStatCov(const RunningStats<Vec3f>& objectStat) const
 {
-	const auto& statVariance = objectStat.getVariance();
+	const auto& statVariance = changeOfBasisTf.rotation() * objectStat.getVariance();
+	const auto& statStdDev = changeOfBasisTf.rotation() * objectStat.getStdDev();
+
 	std::array<float, 6> trackStatCov{};
 	trackStatCov[0] = statVariance.x();
-	trackStatCov[1] = objectStat.getCovarianceXY();
-	trackStatCov[2] = objectStat.getCovarianceZX();
+	trackStatCov[1] = statStdDev.x() * statStdDev.y();
+	trackStatCov[2] = statStdDev.z() * statStdDev.x();
 	trackStatCov[3] = statVariance.y();
-	trackStatCov[4] = objectStat.getCovarianceYZ();
+	trackStatCov[4] = statStdDev.y() * statStdDev.z();
 	trackStatCov[5] = statVariance.z();
 	return trackStatCov;
 }

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -65,19 +65,19 @@ void Ros2PublishRadarTracksNode::ros2EnqueueExecImpl()
 		radarTrack.position.x = position.x();
 		radarTrack.position.y = position.y();
 		radarTrack.position.z = position.z();
-		radarTrack.position = ProcessReferencePoint(radarTrack.position, objectState.orientation.getLastSample(),
+		radarTrack.position = processReferencePoint(radarTrack.position, objectState.orientation.getLastSample(),
 		                                            objectState.length.getMean(), objectState.width.getMean(), signalUnfilled);
-		radarTrack.velocity = ProcessObjectStat<decltype(radarTrack.velocity)>(objectState.absVelocity);
-		radarTrack.acceleration = ProcessObjectStat<decltype(radarTrack.acceleration)>(objectState.absAccel);
+		radarTrack.velocity = processObjectStat<decltype(radarTrack.velocity)>(objectState.absVelocity);
+		radarTrack.acceleration = processObjectStat<decltype(radarTrack.acceleration)>(objectState.absAccel);
 		radarTrack.size.set__x(objectState.length.getMean());
 		radarTrack.size.set__y(objectState.width.getMean());
 		radarTrack.size.set__z(1.0f);
 
-		radarTrack.classification = ProcessObjectProbabilities(objectState.classificationProbabilities);
+		radarTrack.classification = processObjectProbabilities(objectState.classificationProbabilities);
 
-		radarTrack.position_covariance = ProcessObjectStatCov(objectState.position);
-		radarTrack.velocity_covariance = ProcessObjectStatCov(objectState.relVelocity);
-		radarTrack.acceleration_covariance = ProcessObjectStatCov(objectState.relAccel);
+		radarTrack.position_covariance = processObjectStatCov(objectState.position);
+		radarTrack.velocity_covariance = processObjectStatCov(objectState.relVelocity);
+		radarTrack.acceleration_covariance = processObjectStatCov(objectState.relAccel);
 
 		// Height (Z coordinate) is not available in objectState - related covariances are set to 0.
 		radarTrack.size_covariance[0] = objectState.length.getVariance();
@@ -113,7 +113,7 @@ void Ros2PublishRadarTracksNode::configureAgnocastImpl(bool enable)
 }
 #endif
 
-geometry_msgs::msg::Point Ros2PublishRadarTracksNode::ProcessReferencePoint(const geometry_msgs::msg::Point& referencePoint,
+geometry_msgs::msg::Point Ros2PublishRadarTracksNode::processReferencePoint(const geometry_msgs::msg::Point& referencePoint,
                                                                             float yaw, float length, float width,
                                                                             int referenceIndex) const
 {
@@ -144,7 +144,7 @@ geometry_msgs::msg::Point Ros2PublishRadarTracksNode::ProcessReferencePoint(cons
 	return center;
 }
 
-radar_msgs::msg::RadarTrack::_classification_type Ros2PublishRadarTracksNode::ProcessObjectProbabilities(
+radar_msgs::msg::RadarTrack::_classification_type Ros2PublishRadarTracksNode::processObjectProbabilities(
     const RadarTrackObjectsNode::ClassificationProbabilities& probabilities) const
 {
 	constexpr int16_t unknownID = 32000;
@@ -181,7 +181,7 @@ radar_msgs::msg::RadarTrack::_classification_type Ros2PublishRadarTracksNode::Pr
 	return outputClass;
 }
 
-std::array<float, 6> Ros2PublishRadarTracksNode::ProcessObjectStatCov(const RunningStats<Vec3f>& objectStat) const
+std::array<float, 6> Ros2PublishRadarTracksNode::processObjectStatCov(const RunningStats<Vec3f>& objectStat) const
 {
 	const auto& statVariance = changeOfBasisTf.rotation() * objectStat.getVariance();
 	const auto& statStdDev = changeOfBasisTf.rotation() * objectStat.getStdDev();

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -60,17 +60,27 @@ void Ros2PublishRadarTracksNode::ros2EnqueueExecImpl()
 		radarTrack.uuid.uuid[2] = static_cast<uint8_t>((objectState.id >> 16) & 0xff);
 		radarTrack.uuid.uuid[3] = static_cast<uint8_t>((objectState.id >> 24) & 0xff);
 
+		// TODO(Pawel): Check reference point for position (objectSate positionReference fixed to POSITION_REFERENCE_SIGNAL_UNFILLED).
 		radarTrack.position = ProcessObjectStat<decltype(radarTrack.position)>(objectState.position);
 		radarTrack.velocity = ProcessObjectStat<decltype(radarTrack.velocity)>(objectState.absVelocity);
 		radarTrack.acceleration = ProcessObjectStat<decltype(radarTrack.acceleration)>(objectState.absAccel);
-		//radarTrack.size = ProcessObjectStat<decltype(radarTrack.size)>(objectState.dimensions);
+		radarTrack.size.set__x(objectState.length.getMean());
+		radarTrack.size.set__y(objectState.width.getMean());
+		radarTrack.size.set__z(1.0f);
 
 		radarTrack.classification = ProcessObjectProbabilities(objectState.classificationProbabilities);
 
 		radarTrack.position_covariance = ProcessObjectStatCov(objectState.position);
 		radarTrack.velocity_covariance = ProcessObjectStatCov(objectState.relVelocity);
 		radarTrack.acceleration_covariance = ProcessObjectStatCov(objectState.relAccel);
-		//radarTrack.size_covariance = ProcessObjectStatCov(objectState.dimensions);
+
+		constexpr float invalidCovariance = 1e6f;
+		radarTrack.size_covariance[0] = invalidCovariance;
+		radarTrack.size_covariance[1] = 0.0f;
+		radarTrack.size_covariance[2] = 0.0f;
+		radarTrack.size_covariance[3] = invalidCovariance;
+		radarTrack.size_covariance[4] = 0.0f;
+		radarTrack.size_covariance[5] = invalidCovariance;
 
 		++i;
 	}

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -30,7 +30,6 @@ void Ros2PublishRadarTracksNode::setParameters(const char* topicName, const char
 
 void Ros2PublishRadarTracksNode::ros2ValidateImpl()
 {
-	Ros2Node::validateImpl();
 	input = getExactlyOneInputOfType<RadarTrackObjectsNode>(); // Make sure RadarTrackObjectsNode is on the input
 
 	if (input->getHeight() != 1) {

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -1,0 +1,138 @@
+// Copyright 2025 Robotec.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <graph/NodesRos2.hpp>
+#include <scene/Scene.hpp>
+
+void Ros2PublishRadarTracksNode::setParameters(const char* topicName, const char* messageFrameId,
+                                               rgl_qos_policy_reliability_t qosReliability,
+                                               rgl_qos_policy_durability_t qosDurability, rgl_qos_policy_history_t qosHistory,
+                                               int32_t qosHistoryDepth)
+{
+	frameId = messageFrameId;
+	auto qos = rclcpp::QoS(qosHistoryDepth);
+	qos.reliability(static_cast<rmw_qos_reliability_policy_t>(qosReliability));
+	qos.durability(static_cast<rmw_qos_durability_policy_t>(qosDurability));
+	qos.history(static_cast<rmw_qos_history_policy_t>(qosHistory));
+	messagePublisher = std::make_unique<Ros2MessagePublisher<MessageT>>(ros2InitGuard->getNode(), topicName, qos);
+}
+
+void Ros2PublishRadarTracksNode::ros2ValidateImpl()
+{
+	Ros2Node::validateImpl();
+	input = getExactlyOneInputOfType<RadarTrackObjectsNode>(); // Make sure RadarTrackObjectsNode is on the input
+
+	if (input->getHeight() != 1) {
+		throw InvalidPipeline("ROS2 radar track publish supports unorganized pointclouds only");
+	}
+}
+
+void Ros2PublishRadarTracksNode::ros2EnqueueExecImpl()
+{
+	auto& ros2Message = messagePublisher->getMessage();
+
+	ros2Message.header.frame_id = frameId;
+	ros2Message.header.stamp = Scene::instance().getTime().has_value() ?
+	                               Scene::instance().getTime().value().asRos2Msg() :
+	                               static_cast<builtin_interfaces::msg::Time>(ros2InitGuard->getNode().get_clock()->now());
+
+	const auto& objectStates = std::dynamic_pointer_cast<RadarTrackObjectsNode>(input)->getObjectStates();
+	ros2Message.tracks.resize(objectStates.size());
+
+	int i = 0;
+	for (const auto& objectState : objectStates) {
+		auto& radarTrack = ros2Message.tracks[i];
+		radarTrack.uuid.set__uuid({});
+
+		{
+			const auto& objectPosition = objectState.position.getLastSample();
+			radarTrack.position.set__x(objectPosition.x());
+			radarTrack.position.set__y(objectPosition.y());
+			radarTrack.position.set__z(objectPosition.z());
+		}
+		{
+			const auto& objectVelocity = objectState.relVelocity.getLastSample();
+			radarTrack.velocity.set__x(objectVelocity.x());
+			radarTrack.velocity.set__y(objectVelocity.y());
+			radarTrack.velocity.set__z(objectVelocity.z());
+		}
+		{
+			const auto objectAcceleration = objectState.relAccel.getLastSample();
+			radarTrack.acceleration.set__x(objectAcceleration.x());
+			radarTrack.acceleration.set__y(objectAcceleration.y());
+			radarTrack.acceleration.set__z(objectAcceleration.z());
+		}
+		{
+			const Vec3f size = {};
+			radarTrack.size.set__x(size.x());
+			radarTrack.size.set__y(size.y());
+			radarTrack.size.set__z(size.z());
+		}
+
+		radarTrack.classification = radar_msgs::msg::RadarTrack::
+		    NO_CLASSIFICATION; // TODO(Pawel): Decide if we do not want to classify it based on e.g. velocity (STATIC or DYNAMIC object)
+
+		//radarTrack.position_covariance[0] = objectState.position.getCovarianceXX();
+		radarTrack.position_covariance[1] = objectState.position.getCovarianceXY();
+		radarTrack.position_covariance[2] = objectState.position.getCovarianceZX();
+		//radarTrack.position_covariance[3] = objectState.position.getCovarianceYY();
+		radarTrack.position_covariance[4] = objectState.position.getCovarianceYZ();
+		//radarTrack.position_covariance[5] = objectState.position.getCovarianceZZ();
+
+		//radarTrack.velocity_covariance[0] = objectState.relVelocity.getCovarianceXX();
+		radarTrack.velocity_covariance[1] = objectState.relVelocity.getCovarianceXY();
+		radarTrack.velocity_covariance[2] = objectState.relVelocity.getCovarianceZX();
+		//radarTrack.velocity_covariance[3] = objectState.relVelocity.getCovarianceYY();
+		radarTrack.velocity_covariance[4] = objectState.relVelocity.getCovarianceYZ();
+		//radarTrack.velocity_covariance[5] = objectState.relVelocity.getCovarianceZZ();
+
+		//radarTrack.acceleration_covariance[0] = objectState.relAccel.getCovarianceXX();
+		radarTrack.acceleration_covariance[1] = objectState.relAccel.getCovarianceXY();
+		radarTrack.acceleration_covariance[2] = objectState.relAccel.getCovarianceZX();
+		//radarTrack.acceleration_covariance[3] = objectState.relAccel.getCovarianceYY();
+		radarTrack.acceleration_covariance[4] = objectState.relAccel.getCovarianceYZ();
+		//radarTrack.acceleration_covariance[5] = objectState.relAccel.getCovarianceZZ();
+
+		//radarTrack.size_covariance[0] = objectState.dimensions.getCovarianceXX();
+		//radarTrack.size_covariance[1] = objectState.dimensions.getCovarianceXY();
+		//radarTrack.size_covariance[2] = objectState.dimensions.getCovarianceZX();
+		//radarTrack.size_covariance[3] = objectState.dimensions.getCovarianceYY();
+		//radarTrack.size_covariance[4] = objectState.dimensions.getCovarianceYZ();
+		//radarTrack.size_covariance[5] = objectState.dimensions.getCovarianceZZ();
+
+		++i;
+	}
+
+	messagePublisher->publish();
+}
+
+#if RGL_BUILD_AGNOCAST_EXTENSION
+void Ros2PublishRadarTracksNode::configureAgnocastImpl(bool enable)
+{
+	bool isAlreadyAgnocast = dynamic_cast<AgnocastMessagePublisher<MessageT>*>(messagePublisher.get()) != nullptr;
+
+	if (enable == isAlreadyAgnocast) {
+		return; // The current configuration is correct
+	}
+
+	if (enable) {
+		messagePublisher = std::make_unique<AgnocastMessagePublisher<MessageT>>(
+		    ros2InitGuard->getNode(), messagePublisher->getTopicName(), messagePublisher->getQos());
+		return;
+	}
+	// else
+	messagePublisher = std::make_unique<Ros2MessagePublisher<MessageT>>(
+	    ros2InitGuard->getNode(), messagePublisher->getTopicName(), messagePublisher->getQos());
+}
+#endif

--- a/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishRadarTracksNode.cpp
@@ -60,8 +60,10 @@ void Ros2PublishRadarTracksNode::ros2EnqueueExecImpl()
 		radarTrack.uuid.uuid[2] = static_cast<uint8_t>((objectState.id >> 16) & 0xff);
 		radarTrack.uuid.uuid[3] = static_cast<uint8_t>((objectState.id >> 24) & 0xff);
 
-		// TODO(Pawel): Check reference point for position (objectSate positionReference fixed to POSITION_REFERENCE_SIGNAL_UNFILLED).
+		constexpr int signalUnfilled = 255; // According to documentation.
 		radarTrack.position = ProcessObjectStat<decltype(radarTrack.position)>(objectState.position);
+		radarTrack.position = ProcessReferencePoint(radarTrack.position, objectState.orientation.getLastSample(),
+		                                            objectState.length.getMean(), objectState.width.getMean(), signalUnfilled);
 		radarTrack.velocity = ProcessObjectStat<decltype(radarTrack.velocity)>(objectState.absVelocity);
 		radarTrack.acceleration = ProcessObjectStat<decltype(radarTrack.acceleration)>(objectState.absAccel);
 		radarTrack.size.set__x(objectState.length.getMean());
@@ -107,6 +109,37 @@ void Ros2PublishRadarTracksNode::configureAgnocastImpl(bool enable)
 	    ros2InitGuard->getNode(), messagePublisher->getTopicName(), messagePublisher->getQos());
 }
 #endif
+
+geometry_msgs::msg::Point Ros2PublishRadarTracksNode::ProcessReferencePoint(const geometry_msgs::msg::Point& referencePoint,
+                                                                            float yaw, float length, float width,
+                                                                            int referenceIndex) const
+{
+	constexpr int referencePointsCount = 9;
+	constexpr std::array<std::array<float, 2>, referencePointsCount> referenceToCenter = {
+	    {{{-1.0f, -1.0f}},
+	     {{-1.0f, 0.0f}},
+	     {{-1.0f, 1.0f}},
+	     {{0.0f, 1.0f}},
+	     {{1.0f, 1.0f}},
+	     {{1.0f, 0.0f}},
+	     {{1.0f, -1.0f}},
+	     {{0.0f, -1.0f}},
+	     {{0.0f, 0.0f}}}
+    };
+
+	const auto halfLength = 0.5f * length;
+	const auto halfWidth = 0.5f * width;
+	referenceIndex = std::clamp(referenceIndex, 0, referencePointsCount - 1);
+
+	geometry_msgs::msg::Point center;
+	center.set__x(referencePoint.x + std::cos(yaw) * halfLength * referenceToCenter[referenceIndex][0] -
+	              std::sin(yaw) * halfWidth * referenceToCenter[referenceIndex][1]);
+	center.y = referencePoint.y + std::sin(yaw) * halfLength * referenceToCenter[referenceIndex][0] +
+	           std::cos(yaw) * halfWidth * referenceToCenter[referenceIndex][1];
+	center.z = referencePoint.z;
+
+	return center;
+}
 
 radar_msgs::msg::RadarTrack::_classification_type Ros2PublishRadarTracksNode::ProcessObjectProbabilities(
     const RadarTrackObjectsNode::ClassificationProbabilities& probabilities) const

--- a/extensions/ros2/src/tape/TapeRos2.hpp
+++ b/extensions/ros2/src/tape/TapeRos2.hpp
@@ -22,6 +22,7 @@ class TapeRos2
 	static void tape_node_points_ros2_publish(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_points_ros2_publish_with_qos(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_publish_ros2_radarscan(const YAML::Node& yamlNode, PlaybackState& state);
+	static void tape_node_publish_ros2_radartracks(const YAML::Node& yamlNode, PlaybackState& state);
 	static void tape_node_configure_agnocast(const YAML::Node& yamlNode, PlaybackState& state);
 
 	// Called once in the translation unit
@@ -30,6 +31,7 @@ class TapeRos2
 		    TAPE_CALL_MAPPING("rgl_node_points_ros2_publish", TapeRos2::tape_node_points_ros2_publish),
 		    TAPE_CALL_MAPPING("rgl_node_points_ros2_publish_with_qos", TapeRos2::tape_node_points_ros2_publish_with_qos),
 		    TAPE_CALL_MAPPING("rgl_node_publish_ros2_radarscan", TapeRos2::tape_node_publish_ros2_radarscan),
+		    TAPE_CALL_MAPPING("rgl_node_publish_ros2_radartracks", TapeRos2::tape_node_publish_ros2_radartracks),
 		    TAPE_CALL_MAPPING("rgl_node_configure_agnocast", TapeRos2::tape_node_configure_agnocast),
 		};
 		TapePlayer::extendTapeFunctions(tapeFunctions);

--- a/src/graph/RadarTrackObjectsNode.cpp
+++ b/src/graph/RadarTrackObjectsNode.cpp
@@ -265,7 +265,8 @@ void RadarTrackObjectsNode::parseEntityIdToClassProbability(Field<ENTITY_ID_I32>
 	}
 }
 
-const RadarTrackObjectsNode::ObjectState& RadarTrackObjectsNode::createObjectState(const ObjectBounds& objectBounds, double currentTimeMs)
+const RadarTrackObjectsNode::ObjectState& RadarTrackObjectsNode::createObjectState(const ObjectBounds& objectBounds,
+                                                                                   double currentTimeMs)
 {
 	auto& objectState = objectStates.emplace_back();
 	if (objectIDPoll.empty()) {
@@ -296,7 +297,7 @@ const RadarTrackObjectsNode::ObjectState& RadarTrackObjectsNode::createObjectSta
 	// At this moment I just assume that object length is alongside forward axis, and its width is alongside left axis. Note also that
 	// length and width does not have to be correlated to object orientation.
 	objectState.length.addSample(objectBounds.aabb.maxCorner().z() - objectBounds.aabb.minCorner().z());
-	objectState.width.addSample((-objectBounds.aabb.maxCorner().x()) - (-objectBounds.aabb.minCorner().x()));
+	objectState.width.addSample(objectBounds.aabb.maxCorner().x() - objectBounds.aabb.minCorner().x());
 
 	objectState.positionSensorFrame = lookAtSensorFrameTransform * objectState.position.getLastSample();
 	return objectState;
@@ -342,7 +343,7 @@ void RadarTrackObjectsNode::updateObjectState(ObjectState& objectState, const Ve
 
 	if (objectStatus == ObjectStatus::Measured) {
 		objectState.length.addSample(updatedAabb.maxCorner().z() - updatedAabb.minCorner().z());
-		objectState.width.addSample((-updatedAabb.maxCorner().x()) - (-updatedAabb.minCorner().x()));
+		objectState.width.addSample(updatedAabb.maxCorner().x() - updatedAabb.minCorner().x());
 	} else {
 		objectState.length.addSample(objectState.length.getLastSample());
 		objectState.width.addSample(objectState.width.getLastSample());


### PR DESCRIPTION
This PR introduces ROS 2 [RadarTracks](https://docs.ros.org/en/noetic/api/radar_msgs/html/msg/RadarTracks.html) publishing Node. It should be the child Node of RadarTrackObjectsNode.