### PR TITLE
Make PointCloud2 messages `is_dense=true` by default

### DIFF
--- a/extensions/ros2/src/graph/Ros2PublishPointsNode.cpp
+++ b/extensions/ros2/src/graph/Ros2PublishPointsNode.cpp
@@ -59,7 +59,7 @@ void Ros2PublishPointsNode::ros2EnqueueExecImpl()
 	ros2Message.height = 1;
 	ros2Message.width = count;
 	ros2Message.row_step = ros2Message.point_step * ros2Message.width;
-	ros2Message.is_dense = input->isDense();
+	ros2Message.is_dense = true;
 	ros2Message.is_bigendian = std::endian::native == std::endian::big;
 
 	ros2Message.header.frame_id = frameId;


### PR DESCRIPTION
## Background

- From: https://github.com/autowarefoundation/autoware_universe/pull/11853#issuecomment-3732072874

https://github.com/ros2/common_interfaces/blob/jazzy/sensor_msgs/msg/PointCloud2.msg

Basically the rule is:
- If cloud is unorganized (expected by Autoware code):
   - `width = points_count`
   - `height = 1`
   - `row_step = points_count * point_step`
   - `data.size() = row_step`
   - **`is_dense = true` (no NaN points)**
- If cloud is organized (similar to a depth image):
   - `width = horizontal_points_count`
   - `height = vertical_points_count`
   - `row_step = width * point_step`
   - `data.size() = height * row_step`
   - **`is_dense = false` (can have NaN points, not space efficient)**

We might want to reject **non-dense** point clouds by default in autoware too.

I didn't investigate how Autoware handles NaN or Inf in point cloud fields throughout the codebase.

Reference: https://robotics.stackexchange.com/a/73982

## Description

- Fixes: https://github.com/autowarefoundation/autoware_universe/pull/11853#issuecomment-3732164770 (I should turn it into an issue)

I looked around the codebase but couldn't find a mechanism that would set the value of `is_dense` field of the https://github.com/ros2/common_interfaces/blob/rolling/sensor_msgs/msg/PointCloud2.msg

Until it is made possible to set this by the API, let's make it true by default.

Simulations are not expected to send point clouds with NaN points after all.