### PR TITLE
Bump API version (0.21.0), update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Change Log
 
+## [0.21.0] 16 March 2026
+
+### Added
+
+- Added lidar visibility feature (sensors can now ignore specific entities during raytracing)
+  - Added new constants for sensor identification:
+    - `RGL_SENSOR_ID_DEFAULT`
+    - `RGL_SENSOR_ID_NONE`
+  - Added API call to set a sensor ID that will ignore a given entity in raytracing:
+    - `rgl_entity_set_ignored_by_sensor`
+  - Added API call to assign a sensor identifier to RaytraceNode:
+    - `rgl_node_raytrace_configure_id`
+- Added Agnocast extension enabling zero-copy ROS2 publishing via shared memory
+  - Added build option in CMakeLists:
+    - `RGL_BUILD_AGNOCAST_EXTENSION`
+  - Added API call to configure Agnocast on a ROS2 publishing node:
+    - `rgl_node_configure_agnocast`
+- Added detection states to radar nodes
+  - Extended `RadarPostprocessPointsNode` cluster statistics with standard deviations of azimuth, elevation, distance, and radial speed
+  - Added per-detection state data (azimuth, elevation, distance, radial speed with their standard deviations, RCS, detection ID, object ID) to `RadarTrackObjectsNode`
+- Added ROS2 RadarTracks publishing
+  - Added API call to publish [RadarTracks](https://github.com/ros-perception/radar_msgs) message into ROS2 topic:
+    - `rgl_node_publish_ros2_radartracks`
+
+### Changed
+
+- Bumped minimum supported GPU architecture to NVIDIA Turing (GeForce RTX 2000 series, sm_75)
+  - Removed support for older deprecated CUDA architectures
+  - Updated runtime requirements documentation accordingly
+  - This was required to resolve runtime errors observed when running RGL binaries built against the deprecated architecture on the latest NVIDIA drivers
+- Removed tracking of ROS2 publishers in `Ros2InitGuard`
+  - Creating multiple publishers for the same topic is now allowed
+
+### Fixed
+
+- Fixed recursion when retracing rays through ignored entities moving along a triangle surface
+  - Increased the ray iteration offset to reliably avoid re-hitting the same triangle
+- Fixed incorrect error message in `RadarPostprocessPointsNode` validation
+- Fixed object width calculation in `RadarTrackObjectsNode`
+
 ## [0.20.0] 17 December 2024
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,9 +175,7 @@ if (RGL_BUILD_AGNOCAST_EXTENSION)
 endif()
 
 if (RGL_BUILD_ROS2_EXTENSION)
-    if (WIN32) # Workaround for compilation on Windows. fastcdr must be found from the top-level of cmake.
-        find_package(fastcdr REQUIRED)
-    endif()
+    find_package(fastcdr REQUIRED) # fastcdr must be found from the top-level of cmake for some reason.
     add_subdirectory(extensions/ros2)
 endif()
 

--- a/extensions.repos
+++ b/extensions.repos
@@ -2,10 +2,10 @@ repositories:
   extensions/udp:
     type: git
     url: git@github.com:RobotecAI/RGL-extension-udp.git
-    version: develop
+    version: v0.21.0
 
   extensions/weather:
     type: git
     url: git@github.com:RobotecAI/RGL-extension-weather.git
-    version: develop
+    version: v0.21.0
 

--- a/include/rgl/api/core.h
+++ b/include/rgl/api/core.h
@@ -50,7 +50,7 @@
 #define RGL_API NO_MANGLING RGL_VISIBLE
 
 #define RGL_VERSION_MAJOR 0
-#define RGL_VERSION_MINOR 20
+#define RGL_VERSION_MINOR 21
 #define RGL_VERSION_PATCH 0
 
 // Invalid Entity ID is assign to rays that does not hit any Entity.

--- a/install_deps.py
+++ b/install_deps.py
@@ -10,13 +10,13 @@ class Config:
     SPDLOG_VERSION = "v1.9.2"
 
     CMAKE_GIT_VERSION_TRACKING_DIR = os.path.join("external", "cmake_git_version_tracking")
-    CMAKE_GIT_VERSION_TRACKING_VERSION = "904dbda1336ba4b9a1415a68d5f203f576b696bb"
+    CMAKE_GIT_VERSION_TRACKING_VERSION = "18065b734ee59f7628235b2d16546666fff56a93"
 
     YAML_CPP_DIR = os.path.join("external", "yaml-cpp")
-    YAML_CPP_VERSION = "yaml-cpp-0.7.0"
+    YAML_CPP_VERSION = "yaml-cpp-0.9.0"
 
     GOOGLETEST_DIR = os.path.join("external", "googletest")
-    GOOGLETEST_VERSION = "release-1.11.0"
+    GOOGLETEST_VERSION = "v1.17.0"
 
 
 def install_deps():


### PR DESCRIPTION
This PR:
- upgrades some dependencies to avoid cmake errors
- fixes compilation error for ROS 2 extension
- bumps API version and updates changelog